### PR TITLE
Firefox support - use unprefixed rule in demo

### DIFF
--- a/css/demo/demo.css
+++ b/css/demo/demo.css
@@ -144,13 +144,15 @@ h1 span:nth-child(8) {
 @-webkit-keyframes logo-from-horz {
   100% {
     -webkit-transform: translateX(0);
+    transform: translateX(0);
     opacity: 1;
   }
 }
 
 @-o-keyframes logo-from-horz {
   100% {
-    -webkit-transform: translateX(0);
+    -o-transform: translateX(0);
+    transform: translateX(0);
     opacity: 1;
   }
 }
@@ -158,6 +160,9 @@ h1 span:nth-child(8) {
 @keyframes logo-from-horz {
   100% {
     -webkit-transform: translateX(0);
+    -ms-transform: translateX(0);
+    -o-transform: translateX(0);
+    transform: translateX(0);
     opacity: 1;
   }
 }
@@ -165,13 +170,15 @@ h1 span:nth-child(8) {
 @-webkit-keyframes logo-from-vert {
   100% {
     -webkit-transform: translateY(0);
+    transform: translateY(0);
     opacity: 1;
   }
 }
 
 @-o-keyframes logo-from-vert {
   100% {
-    -webkit-transform: translateY(0);
+    -o-transform: translateY(0);
+    transform: translateY(0);
     opacity: 1;
   }
 }
@@ -179,6 +186,9 @@ h1 span:nth-child(8) {
 @keyframes logo-from-vert {
   100% {
     -webkit-transform: translateY(0);
+    -ms-transform: translateY(0);
+    -o-transform: translateY(0);
+    transform: translateY(0);
     opacity: 1;
   }
 }

--- a/scss/demo/demo.scss
+++ b/scss/demo/demo.scss
@@ -86,8 +86,8 @@ h1 span:nth-child(8) {
   transform: translateX(1000px);
 }
 @keyframes logo-from-horz {
-  100% { -webkit-transform: translateX(0); opacity: 1; }
+  100% { transform: translateX(0); opacity: 1; }
 }
 @keyframes logo-from-vert {
-  100% { -webkit-transform: translateY(0); opacity: 1;}
+  100% { transform: translateY(0); opacity: 1;}
 }


### PR DESCRIPTION
Demo page doesn't work in Firefox.  See screenshot below.  By removing `-webkit-` from the scss file, it works in both Chrome and Firefox.

![screen shot 2013-07-03 at 9 28 05 am](https://f.cloud.github.com/assets/95570/743672/d06f1d52-e3ec-11e2-8628-d2ce996e8f9b.png)
