### PR TITLE
Updating deploy task to use grunt-gh-pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.sass-cache/
 node_modules/
+/tmp/

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -82,11 +82,16 @@ module.exports = function(grunt) {
           { expand: true, cwd: './css', src: ['./**/*.*'], dest: 'dist/assets/css' },
           { expand: true, cwd: './js', src: ['./**/*.*'], dest: 'dist/assets/js' }
         ]
-      },
-      deploy: {
-        files: [
-          { expand: true, cwd: './dist', src: ['./**/*.*'], dest: '../gh-pages' }
-        ]
+      }
+    },
+
+    'gh-pages': {
+      demo: {
+        options: {
+          base: './dist',
+          clone: 'tmp/gh-pages'
+        },
+        src: ['**/*']
       }
     }
 
@@ -96,7 +101,7 @@ module.exports = function(grunt) {
   grunt.registerTask('default', ['sass', 'autoprefixer']);
   grunt.registerTask('dev', ['connect', 'watch']);
   grunt.registerTask('demo', ['copy:demo', 'assemble:demo']);
-  grunt.registerTask('deploy', ['copy:deploy']);
+  grunt.registerTask('deploy', ['gh-pages']);
 
   grunt.loadNpmTasks('assemble');
   require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "grunt-contrib-watch": "~0.4.4",
     "grunt-contrib-connect": "~0.3.0",
     "grunt-contrib-copy": "~0.4.1",
-    "assemble": "~0.4.0"
+    "assemble": "~0.4.0",
+    "grunt-gh-pages": "~0.6.0"
   }
 }


### PR DESCRIPTION
From #24, I updated the `grunt deploy` to use the grunt-gh-pages task (based on @cowboy's suggestion) instead of copying the files to a directory and having to manual push up to github.

I hope this is useful and will make the deployment pipeline a little smoother.
