### PR TITLE
Added livereload for css, js & html + updated server port to 8000

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -10,6 +10,13 @@ module.exports = function(grunt) {
         options: {
           livereload: true
         }
+      },
+      livereload: {
+        files: [
+          'dist/*.html',
+          'dist/assets/css/{,*/}*.css',
+          'dist/assets/js/{,*/}*.js'
+        ]
       }
     },
 
@@ -31,7 +38,6 @@ module.exports = function(grunt) {
     },
 
     // https://github.com/nDmitry/grunt-autoprefixer
-    // Too repetative? Or good because we need a web builder with file list?
     autoprefixer: {
       build: {
         options: {


### PR DESCRIPTION
Issue #33 
This "works", but it's not perfect .. is there a way to configure the copy task to only copy the files that have actually been changed? otherwise livereload reloads all the files that have been copied to dist/
