### PR TITLE
Smoothing out Sqwoosh

### DIFF
--- a/css/modules/captions.autoprefixed.css
+++ b/css/modules/captions.autoprefixed.css
@@ -72,27 +72,32 @@
   left: 0;
   width: 100%;
   height: 100%;
-  opacity: 0;
-  -webkit-transition: none;
-  -o-transition: none;
-  transition: none;
   z-index: 0;
 }
 
 .effeckt-caption-3 img {
   position: relative;
   z-index: 1;
+  -webkit-transition-delay: 0.25s;
+  -o-transition-delay: 0.25s;
+  transition-delay: 0.25s;
 }
 
-.effeckt-caption-3:hover figcaption,
-.effeckt-caption-3:active figcaption {
-  opacity: 1;
+.effeckt-caption-3 .effeckt-figcaption-wrap {
+  position: absolute;
+  bottom: 1rem;
+  opacity: 0;
+  -webkit-transition: opacity 0.25s linear 0s;
+  -o-transition: opacity 0.25s linear 0s;
+  transition: opacity 0.25s linear 0s;
 }
 
 .effeckt-caption-3:hover .effeckt-figcaption-wrap,
 .effeckt-caption-3:active .effeckt-figcaption-wrap {
-  position: absolute;
-  bottom: 1rem;
+  opacity: 1;
+  -webkit-transition-delay: 0.25s;
+  -o-transition-delay: 0.25s;
+  transition-delay: 0.25s;
 }
 
 .effeckt-caption-3:hover img,
@@ -101,6 +106,9 @@
   -ms-transform: scale(0.5) translateY(-80px);
   -o-transform: scale(0.5) translateY(-80px);
   transform: scale(0.5) translateY(-80px);
+  -webkit-transition-delay: 0;
+  -o-transition-delay: 0;
+  transition-delay: 0;
 }
 
 .effeckt-caption-4 figcaption {

--- a/css/modules/captions.css
+++ b/css/modules/captions.css
@@ -43,19 +43,22 @@
   left: 0;
   width: 100%;
   height: 100%;
-  opacity: 0;
-  transition: none;
   z-index: 0; }
 .effeckt-caption-3 img {
   position: relative;
-  z-index: 1; }
-.effeckt-caption-3:hover figcaption, .effeckt-caption-3:active figcaption {
-  opacity: 1; }
-.effeckt-caption-3:hover .effeckt-figcaption-wrap, .effeckt-caption-3:active .effeckt-figcaption-wrap {
+  z-index: 1;
+  transition-delay: 0.25s; }
+.effeckt-caption-3 .effeckt-figcaption-wrap {
   position: absolute;
-  bottom: 1rem; }
+  bottom: 1rem;
+  opacity: 0;
+  transition: opacity 0.25s linear 0s; }
+.effeckt-caption-3:hover .effeckt-figcaption-wrap, .effeckt-caption-3:active .effeckt-figcaption-wrap {
+  opacity: 1;
+  transition-delay: 0.25s; }
 .effeckt-caption-3:hover img, .effeckt-caption-3:active img {
-  transform: scale(0.5) translateY(-80px); }
+  transform: scale(0.5) translateY(-80px);
+  transition-delay: 0; }
 
 .effeckt-caption-4 figcaption {
   left: 0;

--- a/dist/assets/css/modules/captions.autoprefixed.css
+++ b/dist/assets/css/modules/captions.autoprefixed.css
@@ -72,27 +72,32 @@
   left: 0;
   width: 100%;
   height: 100%;
-  opacity: 0;
-  -webkit-transition: none;
-  -o-transition: none;
-  transition: none;
   z-index: 0;
 }
 
 .effeckt-caption-3 img {
   position: relative;
   z-index: 1;
+  -webkit-transition-delay: 0.25s;
+  -o-transition-delay: 0.25s;
+  transition-delay: 0.25s;
 }
 
-.effeckt-caption-3:hover figcaption,
-.effeckt-caption-3:active figcaption {
-  opacity: 1;
+.effeckt-caption-3 .effeckt-figcaption-wrap {
+  position: absolute;
+  bottom: 1rem;
+  opacity: 0;
+  -webkit-transition: opacity 0.25s linear 0s;
+  -o-transition: opacity 0.25s linear 0s;
+  transition: opacity 0.25s linear 0s;
 }
 
 .effeckt-caption-3:hover .effeckt-figcaption-wrap,
 .effeckt-caption-3:active .effeckt-figcaption-wrap {
-  position: absolute;
-  bottom: 1rem;
+  opacity: 1;
+  -webkit-transition-delay: 0.25s;
+  -o-transition-delay: 0.25s;
+  transition-delay: 0.25s;
 }
 
 .effeckt-caption-3:hover img,
@@ -101,6 +106,9 @@
   -ms-transform: scale(0.5) translateY(-80px);
   -o-transform: scale(0.5) translateY(-80px);
   transform: scale(0.5) translateY(-80px);
+  -webkit-transition-delay: 0;
+  -o-transition-delay: 0;
+  transition-delay: 0;
 }
 
 .effeckt-caption-4 figcaption {

--- a/dist/assets/css/modules/captions.css
+++ b/dist/assets/css/modules/captions.css
@@ -43,19 +43,22 @@
   left: 0;
   width: 100%;
   height: 100%;
-  opacity: 0;
-  transition: none;
   z-index: 0; }
 .effeckt-caption-3 img {
   position: relative;
-  z-index: 1; }
-.effeckt-caption-3:hover figcaption, .effeckt-caption-3:active figcaption {
-  opacity: 1; }
-.effeckt-caption-3:hover .effeckt-figcaption-wrap, .effeckt-caption-3:active .effeckt-figcaption-wrap {
+  z-index: 1;
+  transition-delay: 0.25s; }
+.effeckt-caption-3 .effeckt-figcaption-wrap {
   position: absolute;
-  bottom: 1rem; }
+  bottom: 1rem;
+  opacity: 0;
+  transition: opacity 0.25s linear 0s; }
+.effeckt-caption-3:hover .effeckt-figcaption-wrap, .effeckt-caption-3:active .effeckt-figcaption-wrap {
+  opacity: 1;
+  transition-delay: 0.25s; }
 .effeckt-caption-3:hover img, .effeckt-caption-3:active img {
-  transform: scale(0.5) translateY(-80px); }
+  transform: scale(0.5) translateY(-80px);
+  transition-delay: 0; }
 
 .effeckt-caption-4 figcaption {
   left: 0;

--- a/scss/modules/captions.css.scss
+++ b/scss/modules/captions.css.scss
@@ -69,24 +69,27 @@
     left: 0;
     width: 100%;
     height: 100%;
-    opacity: 0;
-    transition: none;
     z-index: 0;
   }
   img {
     position: relative;
     z-index: 1;
+    transition-delay: 0.25s;
+  }
+  .effeckt-figcaption-wrap {
+    position: absolute;
+    bottom: 1rem;
+    opacity: 0;
+    transition: opacity 0.25s linear 0s;
   }
   &:hover, &:active {
-    figcaption {
-      opacity: 1;
-    }
     .effeckt-figcaption-wrap {
-      position: absolute;
-      bottom: 1rem;
+      opacity: 1;
+      transition-delay: 0.25s;
     }
     img {
       transform: scale(0.5) translateY(-80px);
+      transition-delay: 0;
     }
   }
 }


### PR DESCRIPTION
A proposal for a better sqwoosh. The current version feels a bit abrupt, particularly when returning to its "at rest" state. This version keeps the `figcaption` in view while returning the image to its full dimensions, while also adding some delay to the wrap when fading in/out. 
