### PR TITLE
Add node engines version

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,5 +12,8 @@
     "assemble": "~0.4.0",
     "grunt-gh-pages": "~0.6.0",
     "grunt-sass": "~0.6.0"
+  },
+  "engines": {
+    "node": ">=0.10"
   }
 }


### PR DESCRIPTION
I forked the project and ran into this problem

![image](https://f.cloud.github.com/assets/810040/847308/ca87736e-f439-11e2-9e24-b811f8d12e39.png)

I had to search the web a bit to find related issues and figure out it was a node version issue (at least for me). Updating to node 0.10 fixed it (I was previously on 0.8 due to some modules being broken on 0.10)

After 0.10

![image](https://f.cloud.github.com/assets/810040/847312/f972162a-f439-11e2-8554-0d0d3ef291e4.png)

The package.json could provide a clue if anyone else has this issue.
