### PR TITLE
Reverse max-width and min-width for modals

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -2,8 +2,8 @@ $effeckt-transition-duration: 500ms !default;
 
 $effeckt-modal-transition-duration: $effeckt-transition-duration !default;
 $effeckt-modal-perspective: 600px !default;
-$effeckt-modal-min-width: 630px !default;
-$effeckt-modal-max-width: 320px !default;
+$effeckt-modal-min-width: 320px !default;
+$effeckt-modal-max-width: 630px !default;
 $effeckt-modal-z-index: 2000 !default;
 
 $effeckt-buttons-transition-duration: $effeckt-transition-duration !default;


### PR DESCRIPTION
It looks to me like the values for max-width and min-width in modals are the wrong way around. 
