### PR TITLE
Convert tooltip styles into a mixin

### DIFF
--- a/css/demo/demo.autoprefixed.css
+++ b/css/demo/demo.autoprefixed.css
@@ -51,7 +51,7 @@ body {
 }
 
 body {
-  background: #eee;
+  background: #eeeeee;
   font-family: Sans-serif;
   overflow-x: hidden;
   padding: 4rem;
@@ -82,7 +82,7 @@ body {
 
 .effeckt header {
   margin: 0 0 1rem 0;
-  border-bottom: 2px solid #eee;
+  border-bottom: 2px solid #eeeeee;
   position: relative;
 }
 
@@ -106,7 +106,7 @@ body {
 
 a {
   text-decoration: none;
-  color: #ccc;
+  color: #cccccc;
 }
 
 a:hover,
@@ -148,7 +148,7 @@ h1 span {
   width: 50px;
   height: 50px;
   line-height: 50px;
-  background: #ccc;
+  background: #cccccc;
   color: white;
   text-align: center;
   text-transform: uppercase;
@@ -190,7 +190,7 @@ button {
 hr {
   height: 0;
   border: 0;
-  border-top: 1px solid #ccc;
+  border-top: 1px solid #cccccc;
 }
 
 h1 span:nth-of-type(1) {
@@ -201,7 +201,7 @@ h1 span:nth-of-type(1) {
   -ms-transform: translateX(-50px);
   -o-transform: translateX(-50px);
   transform: translateX(-50px);
-  background: #666;
+  background: #666666;
 }
 
 h1 span:nth-of-type(2) {
@@ -212,7 +212,7 @@ h1 span:nth-of-type(2) {
   -ms-transform: translateY(-50px);
   -o-transform: translateY(-50px);
   transform: translateY(-50px);
-  background: #444;
+  background: #444444;
 }
 
 h1 span:nth-of-type(3) {
@@ -223,7 +223,7 @@ h1 span:nth-of-type(3) {
   -ms-transform: translateX(50px);
   -o-transform: translateX(50px);
   transform: translateX(50px);
-  background: #666;
+  background: #666666;
 }
 
 h1 span:nth-of-type(4) {
@@ -234,7 +234,7 @@ h1 span:nth-of-type(4) {
   -ms-transform: translateX(50px);
   -o-transform: translateX(50px);
   transform: translateX(50px);
-  background: #444;
+  background: #444444;
 }
 
 h1 span:nth-of-type(5) {
@@ -245,7 +245,7 @@ h1 span:nth-of-type(5) {
   -ms-transform: translateX(-50px);
   -o-transform: translateX(-50px);
   transform: translateX(-50px);
-  background: #666;
+  background: #666666;
 }
 
 h1 span:nth-of-type(6) {
@@ -256,7 +256,7 @@ h1 span:nth-of-type(6) {
   -ms-transform: translateX(50px);
   -o-transform: translateX(50px);
   transform: translateX(50px);
-  background: #444;
+  background: #444444;
 }
 
 h1 span:nth-of-type(7) {
@@ -267,7 +267,7 @@ h1 span:nth-of-type(7) {
   -ms-transform: translateY(-50px);
   -o-transform: translateY(-50px);
   transform: translateY(-50px);
-  background: #666;
+  background: #666666;
 }
 
 h1 span:nth-of-type(8) {
@@ -365,12 +365,12 @@ h1 span:nth-of-type(11) {
 }
 
 .contributors {
-  background: #222;
-  color: #eee;
+  background: #222222;
+  color: #eeeeee;
 }
 
 .contributors header {
-  border-bottom-color: #666;
+  border-bottom-color: #666666;
 }
 
 .contributors .readme {
@@ -464,7 +464,7 @@ h1 span:nth-of-type(11) {
 .effeckt-modal h3 {
   padding: 1rem;
   color: white;
-  background: #444;
+  background: #444444;
 }
 
 .effeckt-modal-content {
@@ -477,7 +477,7 @@ h1 span:nth-of-type(11) {
 }
 
 .effeckt-button {
-  background: #444;
+  background: #444444;
   color: white;
   border: 0;
   padding: 0.8rem 1rem;
@@ -496,7 +496,7 @@ h1 span:nth-of-type(11) {
   height: 100%;
   visibility: hidden;
   overflow: hidden;
-  background: #555;
+  background: #555555;
 }
 
 .effeckt-page-transition-content {
@@ -515,7 +515,7 @@ h1 span:nth-of-type(11) {
   left: 0;
   bottom: 0;
   overflow-y: auto;
-  background: #333;
+  background: #333333;
   visibility: hidden;
   width: 12rem;
 }
@@ -536,21 +536,21 @@ h1 span:nth-of-type(11) {
   display: block;
   padding: 0.3rem 1rem;
   color: white;
-  border-bottom: 1px solid #444;
+  border-bottom: 1px solid #444444;
 }
 
 .effeckt-off-screen-nav li a:hover,
 .effeckt-off-screen-nav li a:focus {
-  background: #444;
+  background: #444444;
 }
 
 .effeckt-off-screen-nav li a:active {
-  background: #222;
+  background: #222222;
 }
 
 .effeckt-off-screen-nav h4 {
   color: white;
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid #eeeeee;
   padding: 1rem 0.5rem 0.2rem 0;
   margin: 0 1rem 1rem;
   text-transform: uppercase;
@@ -618,7 +618,7 @@ h1 span:nth-of-type(11) {
 }
 
 .effeckt-list li.new-item {
-  background: #ccc;
+  background: #cccccc;
 }
 
 .effeckt-list-scroll {
@@ -633,7 +633,7 @@ h1 span:nth-of-type(11) {
 
 .effeckt-list-scroll > li {
   padding: 0.5rem;
-  background: #eee;
+  background: #eeeeee;
   color: #252525;
   font-size: 18px;
 }

--- a/css/demo/demo.css
+++ b/css/demo/demo.css
@@ -34,7 +34,7 @@ html, body {
   height: 100%; }
 
 body {
-  background: #eee;
+  background: #eeeeee;
   font-family: Sans-serif;
   overflow-x: hidden;
   padding: 4rem; }
@@ -55,7 +55,7 @@ body {
       padding: 1.5rem; } }
   .effeckt header {
     margin: 0 0 1rem 0;
-    border-bottom: 2px solid #eee;
+    border-bottom: 2px solid #eeeeee;
     position: relative; }
     .effeckt header .source {
       position: absolute;
@@ -72,7 +72,7 @@ body {
 
 a {
   text-decoration: none;
-  color: #ccc; }
+  color: #cccccc; }
 
 a:hover, a:active {
   color: black; }
@@ -102,7 +102,7 @@ h1 span {
   width: 50px;
   height: 50px;
   line-height: 50px;
-  background: #ccc;
+  background: #cccccc;
   color: white;
   text-align: center;
   text-transform: uppercase; }
@@ -131,42 +131,42 @@ button {
 hr {
   height: 0;
   border: 0;
-  border-top: 1px solid #ccc; }
+  border-top: 1px solid #cccccc; }
 
 h1 span:nth-of-type(1) {
   animation: logo-from-horz 0.5s ease forwards;
   transform: translateX(-50px);
-  background: #666; }
+  background: #666666; }
 
 h1 span:nth-of-type(2) {
   animation: logo-from-vert 0.5s 0.1s ease forwards;
   transform: translateY(-50px);
-  background: #444; }
+  background: #444444; }
 
 h1 span:nth-of-type(3) {
   animation: logo-from-vert 0.5s 0.2s ease forwards;
   transform: translateX(50px);
-  background: #666; }
+  background: #666666; }
 
 h1 span:nth-of-type(4) {
   animation: logo-from-horz 0.3s 0.3s ease forwards;
   transform: translateX(50px);
-  background: #444; }
+  background: #444444; }
 
 h1 span:nth-of-type(5) {
   animation: logo-from-horz 0.3s 0.4s ease forwards;
   transform: translateX(-50px);
-  background: #666; }
+  background: #666666; }
 
 h1 span:nth-of-type(6) {
   animation: logo-from-horz 0.3s 0.5s ease forwards;
   transform: translateX(50px);
-  background: #444; }
+  background: #444444; }
 
 h1 span:nth-of-type(7) {
   animation: logo-from-vert 0.3s 0.6s ease forwards;
   transform: translateY(-50px);
-  background: #666; }
+  background: #666666; }
 
 h1 span:nth-of-type(8) {
   animation: logo-from-horz 0.2s 1.1s ease forwards;
@@ -197,10 +197,10 @@ h1 span:nth-of-type(11) {
     opacity: 1; } }
 
 .contributors {
-  background: #222;
-  color: #eee; }
+  background: #222222;
+  color: #eeeeee; }
   .contributors header {
-    border-bottom-color: #666; }
+    border-bottom-color: #666666; }
   .contributors .readme {
     display: none; }
     .effeckt-demo-captions ~ .contributors .readme {
@@ -263,7 +263,7 @@ h1 span:nth-of-type(11) {
   .effeckt-modal h3 {
     padding: 1rem;
     color: white;
-    background: #444; }
+    background: #444444; }
 
 .effeckt-modal-content {
   padding: 1rem; }
@@ -273,7 +273,7 @@ h1 span:nth-of-type(11) {
   background: rgba(0, 0, 0, 0.5); }
 
 .effeckt-button {
-  background: #444;
+  background: #444444;
   color: white;
   border: 0;
   padding: 0.8rem 1rem;
@@ -291,7 +291,7 @@ h1 span:nth-of-type(11) {
   height: 100%;
   visibility: hidden;
   overflow: hidden;
-  background: #555; }
+  background: #555555; }
 
 .effeckt-page-transition-content {
   position: relative;
@@ -308,7 +308,7 @@ h1 span:nth-of-type(11) {
   left: 0;
   bottom: 0;
   overflow-y: auto;
-  background: #333;
+  background: #333333;
   visibility: hidden;
   width: 12rem; }
   .effeckt-off-screen-nav ul {
@@ -321,14 +321,14 @@ h1 span:nth-of-type(11) {
     display: block;
     padding: 0.3rem 1rem;
     color: white;
-    border-bottom: 1px solid #444; }
+    border-bottom: 1px solid #444444; }
     .effeckt-off-screen-nav li a:hover, .effeckt-off-screen-nav li a:focus {
-      background: #444; }
+      background: #444444; }
     .effeckt-off-screen-nav li a:active {
-      background: #222; }
+      background: #222222; }
   .effeckt-off-screen-nav h4 {
     color: white;
-    border-bottom: 1px solid #eee;
+    border-bottom: 1px solid #eeeeee;
     padding: 1rem 0.5rem 0.2rem 0;
     margin: 0 1rem 1rem;
     text-transform: uppercase;
@@ -373,7 +373,7 @@ h1 span:nth-of-type(11) {
     margin-bottom: 2px;
     line-height: 2; }
     .effeckt-list li.new-item {
-      background: #ccc; }
+      background: #cccccc; }
 
 .effeckt-list-scroll {
   width: 230px;
@@ -385,7 +385,7 @@ h1 span:nth-of-type(11) {
   list-style: none; }
   .effeckt-list-scroll > li {
     padding: 0.5rem;
-    background: #eee;
+    background: #eeeeee;
     color: #252525;
     font-size: 18px; }
     .effeckt-list-scroll > li:nth-child(odd) {

--- a/css/effeckt.autoprefixed.css
+++ b/css/effeckt.autoprefixed.css
@@ -1447,9 +1447,9 @@
   -ms-transform: translateY(-100%);
   -o-transform: translateY(-100%);
   transform: translateY(-100%);
-  -webkit-transition: all .3s;
-  -o-transition: all .3s;
-  transition: all .3s;
+  -webkit-transition: all 0.3s;
+  -o-transition: all 0.3s;
+  transition: all 0.3s;
   opacity: 0;
 }
 
@@ -1572,11 +1572,11 @@
 
 .effeckt-show.md-effect-12 .effeckt-modal {
   opacity: 1;
-  background: #555;
+  background: #555555;
 }
 
 .effeckt-show.md-effect-12 ~ .effeckt-overlay {
-  background: #555;
+  background: #555555;
 }
 
 .md-effect-12,
@@ -3631,15 +3631,15 @@
   position: relative;
 }
 
-.effeckt-tooltip-1[data-effeckt-tooltip-text]::before,
-.effeckt-tooltip-1[data-effeckt-tooltip-text]::after {
+.effeckt-tooltip-top[data-effeckt-tooltip-text]::before,
+.effeckt-tooltip-top[data-effeckt-tooltip-text]::after {
   opacity: 0;
   -webkit-transition: 0.2s;
   -o-transition: 0.2s;
   transition: 0.2s;
 }
 
-.effeckt-tooltip-1[data-effeckt-tooltip-text]::after {
+.effeckt-tooltip-top[data-effeckt-tooltip-text]::after {
   content: attr(data-effeckt-tooltip-text);
   position: absolute;
   left: 50%;
@@ -3647,9 +3647,8 @@
   -ms-transform: translateX(-50%);
   -o-transform: translateX(-50%);
   transform: translateX(-50%);
-  bottom: 125%;
   border-radius: 10px;
-  background: #333;
+  background: #333333;
   color: white;
   padding: 0.45rem 0.8rem;
   font-size: 90%;
@@ -3657,40 +3656,50 @@
   visibility: hidden;
 }
 
-.effeckt-tooltip-1[data-effeckt-tooltip-text]::before {
+.effeckt-tooltip-top[data-effeckt-tooltip-text]::before {
   content: "";
   width: 0;
   height: 0;
-  border-top: 5px solid #333;
   border-left: 5px solid transparent;
   border-right: 5px solid transparent;
   position: absolute;
+  left: 50%;
+  margin-left: -5px;
+}
+
+.effeckt-tooltip-top[data-effeckt-tooltip-text]:hover::before,
+.effeckt-tooltip-top[data-effeckt-tooltip-text]:hover::after {
+  visibility: visible;
+  opacity: 1;
+  -webkit-transition: 0.2s 0.3s;
+  -o-transition: 0.2s 0.3s;
+  transition: 0.2s 0.3s;
+}
+
+.effeckt-tooltip-top[data-effeckt-tooltip-text]::after {
+  bottom: 125%;
+}
+
+.effeckt-tooltip-top[data-effeckt-tooltip-text]::before {
+  border-top: 5px solid #333333;
   bottom: 125%;
   margin-bottom: -4px;
-  left: 50%;
-  margin-left: -5px;
 }
 
-.effeckt-tooltip-1[data-effeckt-tooltip-text]:hover::before,
-.effeckt-tooltip-1[data-effeckt-tooltip-text]:hover::after {
-  visibility: visible;
-  opacity: 1;
+.effeckt-tooltip-top[data-effeckt-tooltip-text]:hover::before,
+.effeckt-tooltip-top[data-effeckt-tooltip-text]:hover::after {
   bottom: 115%;
-  -webkit-transition: 0.2s 0.3s;
-  -o-transition: 0.2s 0.3s;
-  transition: 0.2s 0.3s;
 }
 
-.effeckt-tooltip-2[data-effeckt-tooltip-text]::before,
-.effeckt-tooltip-2[data-effeckt-tooltip-text]::after {
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]::before,
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]::after {
   opacity: 0;
-  visibility: hidden;
   -webkit-transition: 0.2s;
   -o-transition: 0.2s;
   transition: 0.2s;
 }
 
-.effeckt-tooltip-2[data-effeckt-tooltip-text]::after {
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]::after {
   content: attr(data-effeckt-tooltip-text);
   position: absolute;
   left: 50%;
@@ -3698,35 +3707,46 @@
   -ms-transform: translateX(-50%);
   -o-transform: translateX(-50%);
   transform: translateX(-50%);
-  top: 125%;
   border-radius: 10px;
-  background: #333;
+  background: #333333;
   color: white;
   padding: 0.45rem 0.8rem;
   font-size: 90%;
   white-space: nowrap;
+  visibility: hidden;
 }
 
-.effeckt-tooltip-2[data-effeckt-tooltip-text]::before {
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]::before {
   content: "";
   width: 0;
   height: 0;
-  border-bottom: 5px solid #333;
   border-left: 5px solid transparent;
   border-right: 5px solid transparent;
   position: absolute;
-  top: 125%;
-  margin-top: -4px;
   left: 50%;
   margin-left: -5px;
 }
 
-.effeckt-tooltip-2[data-effeckt-tooltip-text]:hover::before,
-.effeckt-tooltip-2[data-effeckt-tooltip-text]:hover::after {
-  opacity: 1;
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]:hover::before,
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]:hover::after {
   visibility: visible;
-  top: 115%;
+  opacity: 1;
   -webkit-transition: 0.2s 0.3s;
   -o-transition: 0.2s 0.3s;
   transition: 0.2s 0.3s;
+}
+
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]::after {
+  top: 125%;
+}
+
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]::before {
+  border-bottom: 5px solid #333333;
+  top: 125%;
+  margin-top: -4px;
+}
+
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]:hover::before,
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]:hover::after {
+  top: 115%;
 }

--- a/css/effeckt.css
+++ b/css/effeckt.css
@@ -625,7 +625,7 @@
 
 .md-effect-7 .effeckt-modal {
   transform: translateY(-100%);
-  transition: all .3s;
+  transition: all 0.3s;
   opacity: 0; }
 
 .effeckt-show.md-effect-7 .effeckt-modal {
@@ -682,10 +682,10 @@
 
 .effeckt-show.md-effect-12 .effeckt-modal {
   opacity: 1;
-  background: #555; }
+  background: #555555; }
 
 .effeckt-show.md-effect-12 ~ .effeckt-overlay {
-  background: #555; }
+  background: #555555; }
 
 .md-effect-12, .md-effect-12 h3 {
   background: transparent; }
@@ -1316,70 +1316,76 @@
 [data-effeckt-tooltip-text] {
   position: relative; }
 
-.effeckt-tooltip-1[data-effeckt-tooltip-text]::before, .effeckt-tooltip-1[data-effeckt-tooltip-text]::after {
+.effeckt-tooltip-top[data-effeckt-tooltip-text]::before, .effeckt-tooltip-top[data-effeckt-tooltip-text]::after {
   opacity: 0;
   transition: 0.2s; }
-.effeckt-tooltip-1[data-effeckt-tooltip-text]::after {
+.effeckt-tooltip-top[data-effeckt-tooltip-text]::after {
   content: attr(data-effeckt-tooltip-text);
   position: absolute;
   left: 50%;
   transform: translateX(-50%);
-  bottom: 125%;
   border-radius: 10px;
-  background: #333;
+  background: #333333;
   color: white;
   padding: 0.45rem 0.8rem;
   font-size: 90%;
   white-space: nowrap;
   visibility: hidden; }
-.effeckt-tooltip-1[data-effeckt-tooltip-text]::before {
+.effeckt-tooltip-top[data-effeckt-tooltip-text]::before {
   content: "";
   width: 0;
   height: 0;
-  border-top: 5px solid #333;
   border-left: 5px solid transparent;
   border-right: 5px solid transparent;
   position: absolute;
-  bottom: 125%;
-  margin-bottom: -4px;
   left: 50%;
   margin-left: -5px; }
-.effeckt-tooltip-1[data-effeckt-tooltip-text]:hover::before, .effeckt-tooltip-1[data-effeckt-tooltip-text]:hover::after {
+.effeckt-tooltip-top[data-effeckt-tooltip-text]:hover::before, .effeckt-tooltip-top[data-effeckt-tooltip-text]:hover::after {
   visibility: visible;
   opacity: 1;
-  bottom: 115%;
   transition: 0.2s 0.3s; }
+.effeckt-tooltip-top[data-effeckt-tooltip-text]::after {
+  bottom: 125%; }
+.effeckt-tooltip-top[data-effeckt-tooltip-text]::before {
+  border-top: 5px solid #333333;
+  bottom: 125%;
+  margin-bottom: -4px; }
+.effeckt-tooltip-top[data-effeckt-tooltip-text]:hover::before, .effeckt-tooltip-top[data-effeckt-tooltip-text]:hover::after {
+  bottom: 115%; }
 
-.effeckt-tooltip-2[data-effeckt-tooltip-text]::before, .effeckt-tooltip-2[data-effeckt-tooltip-text]::after {
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]::before, .effeckt-tooltip-bottom[data-effeckt-tooltip-text]::after {
   opacity: 0;
-  visibility: hidden;
   transition: 0.2s; }
-.effeckt-tooltip-2[data-effeckt-tooltip-text]::after {
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]::after {
   content: attr(data-effeckt-tooltip-text);
   position: absolute;
   left: 50%;
   transform: translateX(-50%);
-  top: 125%;
   border-radius: 10px;
-  background: #333;
+  background: #333333;
   color: white;
   padding: 0.45rem 0.8rem;
   font-size: 90%;
-  white-space: nowrap; }
-.effeckt-tooltip-2[data-effeckt-tooltip-text]::before {
+  white-space: nowrap;
+  visibility: hidden; }
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]::before {
   content: "";
   width: 0;
   height: 0;
-  border-bottom: 5px solid #333;
   border-left: 5px solid transparent;
   border-right: 5px solid transparent;
   position: absolute;
-  top: 125%;
-  margin-top: -4px;
   left: 50%;
   margin-left: -5px; }
-.effeckt-tooltip-2[data-effeckt-tooltip-text]:hover::before, .effeckt-tooltip-2[data-effeckt-tooltip-text]:hover::after {
-  opacity: 1;
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]:hover::before, .effeckt-tooltip-bottom[data-effeckt-tooltip-text]:hover::after {
   visibility: visible;
-  top: 115%;
+  opacity: 1;
   transition: 0.2s 0.3s; }
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]::after {
+  top: 125%; }
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]::before {
+  border-bottom: 5px solid #333333;
+  top: 125%;
+  margin-top: -4px; }
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]:hover::before, .effeckt-tooltip-bottom[data-effeckt-tooltip-text]:hover::after {
+  top: 115%; }

--- a/css/modules/modals.autoprefixed.css
+++ b/css/modules/modals.autoprefixed.css
@@ -215,9 +215,9 @@
   -ms-transform: translateY(-100%);
   -o-transform: translateY(-100%);
   transform: translateY(-100%);
-  -webkit-transition: all .3s;
-  -o-transition: all .3s;
-  transition: all .3s;
+  -webkit-transition: all 0.3s;
+  -o-transition: all 0.3s;
+  transition: all 0.3s;
   opacity: 0;
 }
 
@@ -340,11 +340,11 @@
 
 .effeckt-show.md-effect-12 .effeckt-modal {
   opacity: 1;
-  background: #555;
+  background: #555555;
 }
 
 .effeckt-show.md-effect-12 ~ .effeckt-overlay {
-  background: #555;
+  background: #555555;
 }
 
 .md-effect-12,

--- a/css/modules/modals.css
+++ b/css/modules/modals.css
@@ -114,7 +114,7 @@
 
 .md-effect-7 .effeckt-modal {
   transform: translateY(-100%);
-  transition: all .3s;
+  transition: all 0.3s;
   opacity: 0; }
 
 .effeckt-show.md-effect-7 .effeckt-modal {
@@ -171,10 +171,10 @@
 
 .effeckt-show.md-effect-12 .effeckt-modal {
   opacity: 1;
-  background: #555; }
+  background: #555555; }
 
 .effeckt-show.md-effect-12 ~ .effeckt-overlay {
-  background: #555; }
+  background: #555555; }
 
 .md-effect-12, .md-effect-12 h3 {
   background: transparent; }

--- a/css/modules/tooltips.autoprefixed.css
+++ b/css/modules/tooltips.autoprefixed.css
@@ -2,15 +2,15 @@
   position: relative;
 }
 
-.effeckt-tooltip-1[data-effeckt-tooltip-text]::before,
-.effeckt-tooltip-1[data-effeckt-tooltip-text]::after {
+.effeckt-tooltip-top[data-effeckt-tooltip-text]::before,
+.effeckt-tooltip-top[data-effeckt-tooltip-text]::after {
   opacity: 0;
   -webkit-transition: 0.2s;
   -o-transition: 0.2s;
   transition: 0.2s;
 }
 
-.effeckt-tooltip-1[data-effeckt-tooltip-text]::after {
+.effeckt-tooltip-top[data-effeckt-tooltip-text]::after {
   content: attr(data-effeckt-tooltip-text);
   position: absolute;
   left: 50%;
@@ -18,9 +18,8 @@
   -ms-transform: translateX(-50%);
   -o-transform: translateX(-50%);
   transform: translateX(-50%);
-  bottom: 125%;
   border-radius: 10px;
-  background: #333;
+  background: #333333;
   color: white;
   padding: 0.45rem 0.8rem;
   font-size: 90%;
@@ -28,40 +27,50 @@
   visibility: hidden;
 }
 
-.effeckt-tooltip-1[data-effeckt-tooltip-text]::before {
+.effeckt-tooltip-top[data-effeckt-tooltip-text]::before {
   content: "";
   width: 0;
   height: 0;
-  border-top: 5px solid #333;
   border-left: 5px solid transparent;
   border-right: 5px solid transparent;
   position: absolute;
+  left: 50%;
+  margin-left: -5px;
+}
+
+.effeckt-tooltip-top[data-effeckt-tooltip-text]:hover::before,
+.effeckt-tooltip-top[data-effeckt-tooltip-text]:hover::after {
+  visibility: visible;
+  opacity: 1;
+  -webkit-transition: 0.2s 0.3s;
+  -o-transition: 0.2s 0.3s;
+  transition: 0.2s 0.3s;
+}
+
+.effeckt-tooltip-top[data-effeckt-tooltip-text]::after {
+  bottom: 125%;
+}
+
+.effeckt-tooltip-top[data-effeckt-tooltip-text]::before {
+  border-top: 5px solid #333333;
   bottom: 125%;
   margin-bottom: -4px;
-  left: 50%;
-  margin-left: -5px;
 }
 
-.effeckt-tooltip-1[data-effeckt-tooltip-text]:hover::before,
-.effeckt-tooltip-1[data-effeckt-tooltip-text]:hover::after {
-  visibility: visible;
-  opacity: 1;
+.effeckt-tooltip-top[data-effeckt-tooltip-text]:hover::before,
+.effeckt-tooltip-top[data-effeckt-tooltip-text]:hover::after {
   bottom: 115%;
-  -webkit-transition: 0.2s 0.3s;
-  -o-transition: 0.2s 0.3s;
-  transition: 0.2s 0.3s;
 }
 
-.effeckt-tooltip-2[data-effeckt-tooltip-text]::before,
-.effeckt-tooltip-2[data-effeckt-tooltip-text]::after {
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]::before,
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]::after {
   opacity: 0;
-  visibility: hidden;
   -webkit-transition: 0.2s;
   -o-transition: 0.2s;
   transition: 0.2s;
 }
 
-.effeckt-tooltip-2[data-effeckt-tooltip-text]::after {
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]::after {
   content: attr(data-effeckt-tooltip-text);
   position: absolute;
   left: 50%;
@@ -69,35 +78,46 @@
   -ms-transform: translateX(-50%);
   -o-transform: translateX(-50%);
   transform: translateX(-50%);
-  top: 125%;
   border-radius: 10px;
-  background: #333;
+  background: #333333;
   color: white;
   padding: 0.45rem 0.8rem;
   font-size: 90%;
   white-space: nowrap;
+  visibility: hidden;
 }
 
-.effeckt-tooltip-2[data-effeckt-tooltip-text]::before {
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]::before {
   content: "";
   width: 0;
   height: 0;
-  border-bottom: 5px solid #333;
   border-left: 5px solid transparent;
   border-right: 5px solid transparent;
   position: absolute;
-  top: 125%;
-  margin-top: -4px;
   left: 50%;
   margin-left: -5px;
 }
 
-.effeckt-tooltip-2[data-effeckt-tooltip-text]:hover::before,
-.effeckt-tooltip-2[data-effeckt-tooltip-text]:hover::after {
-  opacity: 1;
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]:hover::before,
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]:hover::after {
   visibility: visible;
-  top: 115%;
+  opacity: 1;
   -webkit-transition: 0.2s 0.3s;
   -o-transition: 0.2s 0.3s;
   transition: 0.2s 0.3s;
+}
+
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]::after {
+  top: 125%;
+}
+
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]::before {
+  border-bottom: 5px solid #333333;
+  top: 125%;
+  margin-top: -4px;
+}
+
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]:hover::before,
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]:hover::after {
+  top: 115%;
 }

--- a/css/modules/tooltips.css
+++ b/css/modules/tooltips.css
@@ -1,70 +1,76 @@
 [data-effeckt-tooltip-text] {
   position: relative; }
 
-.effeckt-tooltip-1[data-effeckt-tooltip-text]::before, .effeckt-tooltip-1[data-effeckt-tooltip-text]::after {
+.effeckt-tooltip-top[data-effeckt-tooltip-text]::before, .effeckt-tooltip-top[data-effeckt-tooltip-text]::after {
   opacity: 0;
   transition: 0.2s; }
-.effeckt-tooltip-1[data-effeckt-tooltip-text]::after {
+.effeckt-tooltip-top[data-effeckt-tooltip-text]::after {
   content: attr(data-effeckt-tooltip-text);
   position: absolute;
   left: 50%;
   transform: translateX(-50%);
-  bottom: 125%;
   border-radius: 10px;
-  background: #333;
+  background: #333333;
   color: white;
   padding: 0.45rem 0.8rem;
   font-size: 90%;
   white-space: nowrap;
   visibility: hidden; }
-.effeckt-tooltip-1[data-effeckt-tooltip-text]::before {
+.effeckt-tooltip-top[data-effeckt-tooltip-text]::before {
   content: "";
   width: 0;
   height: 0;
-  border-top: 5px solid #333;
   border-left: 5px solid transparent;
   border-right: 5px solid transparent;
   position: absolute;
-  bottom: 125%;
-  margin-bottom: -4px;
   left: 50%;
   margin-left: -5px; }
-.effeckt-tooltip-1[data-effeckt-tooltip-text]:hover::before, .effeckt-tooltip-1[data-effeckt-tooltip-text]:hover::after {
+.effeckt-tooltip-top[data-effeckt-tooltip-text]:hover::before, .effeckt-tooltip-top[data-effeckt-tooltip-text]:hover::after {
   visibility: visible;
   opacity: 1;
-  bottom: 115%;
   transition: 0.2s 0.3s; }
+.effeckt-tooltip-top[data-effeckt-tooltip-text]::after {
+  bottom: 125%; }
+.effeckt-tooltip-top[data-effeckt-tooltip-text]::before {
+  border-top: 5px solid #333333;
+  bottom: 125%;
+  margin-bottom: -4px; }
+.effeckt-tooltip-top[data-effeckt-tooltip-text]:hover::before, .effeckt-tooltip-top[data-effeckt-tooltip-text]:hover::after {
+  bottom: 115%; }
 
-.effeckt-tooltip-2[data-effeckt-tooltip-text]::before, .effeckt-tooltip-2[data-effeckt-tooltip-text]::after {
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]::before, .effeckt-tooltip-bottom[data-effeckt-tooltip-text]::after {
   opacity: 0;
-  visibility: hidden;
   transition: 0.2s; }
-.effeckt-tooltip-2[data-effeckt-tooltip-text]::after {
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]::after {
   content: attr(data-effeckt-tooltip-text);
   position: absolute;
   left: 50%;
   transform: translateX(-50%);
-  top: 125%;
   border-radius: 10px;
-  background: #333;
+  background: #333333;
   color: white;
   padding: 0.45rem 0.8rem;
   font-size: 90%;
-  white-space: nowrap; }
-.effeckt-tooltip-2[data-effeckt-tooltip-text]::before {
+  white-space: nowrap;
+  visibility: hidden; }
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]::before {
   content: "";
   width: 0;
   height: 0;
-  border-bottom: 5px solid #333;
   border-left: 5px solid transparent;
   border-right: 5px solid transparent;
   position: absolute;
-  top: 125%;
-  margin-top: -4px;
   left: 50%;
   margin-left: -5px; }
-.effeckt-tooltip-2[data-effeckt-tooltip-text]:hover::before, .effeckt-tooltip-2[data-effeckt-tooltip-text]:hover::after {
-  opacity: 1;
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]:hover::before, .effeckt-tooltip-bottom[data-effeckt-tooltip-text]:hover::after {
   visibility: visible;
-  top: 115%;
+  opacity: 1;
   transition: 0.2s 0.3s; }
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]::after {
+  top: 125%; }
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]::before {
+  border-bottom: 5px solid #333333;
+  top: 125%;
+  margin-top: -4px; }
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]:hover::before, .effeckt-tooltip-bottom[data-effeckt-tooltip-text]:hover::after {
+  top: 115%; }

--- a/dist/assets/css/demo/demo.autoprefixed.css
+++ b/dist/assets/css/demo/demo.autoprefixed.css
@@ -51,7 +51,7 @@ body {
 }
 
 body {
-  background: #eee;
+  background: #eeeeee;
   font-family: Sans-serif;
   overflow-x: hidden;
   padding: 4rem;
@@ -82,7 +82,7 @@ body {
 
 .effeckt header {
   margin: 0 0 1rem 0;
-  border-bottom: 2px solid #eee;
+  border-bottom: 2px solid #eeeeee;
   position: relative;
 }
 
@@ -106,7 +106,7 @@ body {
 
 a {
   text-decoration: none;
-  color: #ccc;
+  color: #cccccc;
 }
 
 a:hover,
@@ -148,7 +148,7 @@ h1 span {
   width: 50px;
   height: 50px;
   line-height: 50px;
-  background: #ccc;
+  background: #cccccc;
   color: white;
   text-align: center;
   text-transform: uppercase;
@@ -190,7 +190,7 @@ button {
 hr {
   height: 0;
   border: 0;
-  border-top: 1px solid #ccc;
+  border-top: 1px solid #cccccc;
 }
 
 h1 span:nth-of-type(1) {
@@ -201,7 +201,7 @@ h1 span:nth-of-type(1) {
   -ms-transform: translateX(-50px);
   -o-transform: translateX(-50px);
   transform: translateX(-50px);
-  background: #666;
+  background: #666666;
 }
 
 h1 span:nth-of-type(2) {
@@ -212,7 +212,7 @@ h1 span:nth-of-type(2) {
   -ms-transform: translateY(-50px);
   -o-transform: translateY(-50px);
   transform: translateY(-50px);
-  background: #444;
+  background: #444444;
 }
 
 h1 span:nth-of-type(3) {
@@ -223,7 +223,7 @@ h1 span:nth-of-type(3) {
   -ms-transform: translateX(50px);
   -o-transform: translateX(50px);
   transform: translateX(50px);
-  background: #666;
+  background: #666666;
 }
 
 h1 span:nth-of-type(4) {
@@ -234,7 +234,7 @@ h1 span:nth-of-type(4) {
   -ms-transform: translateX(50px);
   -o-transform: translateX(50px);
   transform: translateX(50px);
-  background: #444;
+  background: #444444;
 }
 
 h1 span:nth-of-type(5) {
@@ -245,7 +245,7 @@ h1 span:nth-of-type(5) {
   -ms-transform: translateX(-50px);
   -o-transform: translateX(-50px);
   transform: translateX(-50px);
-  background: #666;
+  background: #666666;
 }
 
 h1 span:nth-of-type(6) {
@@ -256,7 +256,7 @@ h1 span:nth-of-type(6) {
   -ms-transform: translateX(50px);
   -o-transform: translateX(50px);
   transform: translateX(50px);
-  background: #444;
+  background: #444444;
 }
 
 h1 span:nth-of-type(7) {
@@ -267,7 +267,7 @@ h1 span:nth-of-type(7) {
   -ms-transform: translateY(-50px);
   -o-transform: translateY(-50px);
   transform: translateY(-50px);
-  background: #666;
+  background: #666666;
 }
 
 h1 span:nth-of-type(8) {
@@ -365,12 +365,12 @@ h1 span:nth-of-type(11) {
 }
 
 .contributors {
-  background: #222;
-  color: #eee;
+  background: #222222;
+  color: #eeeeee;
 }
 
 .contributors header {
-  border-bottom-color: #666;
+  border-bottom-color: #666666;
 }
 
 .contributors .readme {
@@ -464,7 +464,7 @@ h1 span:nth-of-type(11) {
 .effeckt-modal h3 {
   padding: 1rem;
   color: white;
-  background: #444;
+  background: #444444;
 }
 
 .effeckt-modal-content {
@@ -477,7 +477,7 @@ h1 span:nth-of-type(11) {
 }
 
 .effeckt-button {
-  background: #444;
+  background: #444444;
   color: white;
   border: 0;
   padding: 0.8rem 1rem;
@@ -496,7 +496,7 @@ h1 span:nth-of-type(11) {
   height: 100%;
   visibility: hidden;
   overflow: hidden;
-  background: #555;
+  background: #555555;
 }
 
 .effeckt-page-transition-content {
@@ -515,7 +515,7 @@ h1 span:nth-of-type(11) {
   left: 0;
   bottom: 0;
   overflow-y: auto;
-  background: #333;
+  background: #333333;
   visibility: hidden;
   width: 12rem;
 }
@@ -536,21 +536,21 @@ h1 span:nth-of-type(11) {
   display: block;
   padding: 0.3rem 1rem;
   color: white;
-  border-bottom: 1px solid #444;
+  border-bottom: 1px solid #444444;
 }
 
 .effeckt-off-screen-nav li a:hover,
 .effeckt-off-screen-nav li a:focus {
-  background: #444;
+  background: #444444;
 }
 
 .effeckt-off-screen-nav li a:active {
-  background: #222;
+  background: #222222;
 }
 
 .effeckt-off-screen-nav h4 {
   color: white;
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid #eeeeee;
   padding: 1rem 0.5rem 0.2rem 0;
   margin: 0 1rem 1rem;
   text-transform: uppercase;
@@ -618,7 +618,7 @@ h1 span:nth-of-type(11) {
 }
 
 .effeckt-list li.new-item {
-  background: #ccc;
+  background: #cccccc;
 }
 
 .effeckt-list-scroll {
@@ -633,7 +633,7 @@ h1 span:nth-of-type(11) {
 
 .effeckt-list-scroll > li {
   padding: 0.5rem;
-  background: #eee;
+  background: #eeeeee;
   color: #252525;
   font-size: 18px;
 }

--- a/dist/assets/css/demo/demo.css
+++ b/dist/assets/css/demo/demo.css
@@ -34,7 +34,7 @@ html, body {
   height: 100%; }
 
 body {
-  background: #eee;
+  background: #eeeeee;
   font-family: Sans-serif;
   overflow-x: hidden;
   padding: 4rem; }
@@ -55,7 +55,7 @@ body {
       padding: 1.5rem; } }
   .effeckt header {
     margin: 0 0 1rem 0;
-    border-bottom: 2px solid #eee;
+    border-bottom: 2px solid #eeeeee;
     position: relative; }
     .effeckt header .source {
       position: absolute;
@@ -72,7 +72,7 @@ body {
 
 a {
   text-decoration: none;
-  color: #ccc; }
+  color: #cccccc; }
 
 a:hover, a:active {
   color: black; }
@@ -102,7 +102,7 @@ h1 span {
   width: 50px;
   height: 50px;
   line-height: 50px;
-  background: #ccc;
+  background: #cccccc;
   color: white;
   text-align: center;
   text-transform: uppercase; }
@@ -131,42 +131,42 @@ button {
 hr {
   height: 0;
   border: 0;
-  border-top: 1px solid #ccc; }
+  border-top: 1px solid #cccccc; }
 
 h1 span:nth-of-type(1) {
   animation: logo-from-horz 0.5s ease forwards;
   transform: translateX(-50px);
-  background: #666; }
+  background: #666666; }
 
 h1 span:nth-of-type(2) {
   animation: logo-from-vert 0.5s 0.1s ease forwards;
   transform: translateY(-50px);
-  background: #444; }
+  background: #444444; }
 
 h1 span:nth-of-type(3) {
   animation: logo-from-vert 0.5s 0.2s ease forwards;
   transform: translateX(50px);
-  background: #666; }
+  background: #666666; }
 
 h1 span:nth-of-type(4) {
   animation: logo-from-horz 0.3s 0.3s ease forwards;
   transform: translateX(50px);
-  background: #444; }
+  background: #444444; }
 
 h1 span:nth-of-type(5) {
   animation: logo-from-horz 0.3s 0.4s ease forwards;
   transform: translateX(-50px);
-  background: #666; }
+  background: #666666; }
 
 h1 span:nth-of-type(6) {
   animation: logo-from-horz 0.3s 0.5s ease forwards;
   transform: translateX(50px);
-  background: #444; }
+  background: #444444; }
 
 h1 span:nth-of-type(7) {
   animation: logo-from-vert 0.3s 0.6s ease forwards;
   transform: translateY(-50px);
-  background: #666; }
+  background: #666666; }
 
 h1 span:nth-of-type(8) {
   animation: logo-from-horz 0.2s 1.1s ease forwards;
@@ -197,10 +197,10 @@ h1 span:nth-of-type(11) {
     opacity: 1; } }
 
 .contributors {
-  background: #222;
-  color: #eee; }
+  background: #222222;
+  color: #eeeeee; }
   .contributors header {
-    border-bottom-color: #666; }
+    border-bottom-color: #666666; }
   .contributors .readme {
     display: none; }
     .effeckt-demo-captions ~ .contributors .readme {
@@ -263,7 +263,7 @@ h1 span:nth-of-type(11) {
   .effeckt-modal h3 {
     padding: 1rem;
     color: white;
-    background: #444; }
+    background: #444444; }
 
 .effeckt-modal-content {
   padding: 1rem; }
@@ -273,7 +273,7 @@ h1 span:nth-of-type(11) {
   background: rgba(0, 0, 0, 0.5); }
 
 .effeckt-button {
-  background: #444;
+  background: #444444;
   color: white;
   border: 0;
   padding: 0.8rem 1rem;
@@ -291,7 +291,7 @@ h1 span:nth-of-type(11) {
   height: 100%;
   visibility: hidden;
   overflow: hidden;
-  background: #555; }
+  background: #555555; }
 
 .effeckt-page-transition-content {
   position: relative;
@@ -308,7 +308,7 @@ h1 span:nth-of-type(11) {
   left: 0;
   bottom: 0;
   overflow-y: auto;
-  background: #333;
+  background: #333333;
   visibility: hidden;
   width: 12rem; }
   .effeckt-off-screen-nav ul {
@@ -321,14 +321,14 @@ h1 span:nth-of-type(11) {
     display: block;
     padding: 0.3rem 1rem;
     color: white;
-    border-bottom: 1px solid #444; }
+    border-bottom: 1px solid #444444; }
     .effeckt-off-screen-nav li a:hover, .effeckt-off-screen-nav li a:focus {
-      background: #444; }
+      background: #444444; }
     .effeckt-off-screen-nav li a:active {
-      background: #222; }
+      background: #222222; }
   .effeckt-off-screen-nav h4 {
     color: white;
-    border-bottom: 1px solid #eee;
+    border-bottom: 1px solid #eeeeee;
     padding: 1rem 0.5rem 0.2rem 0;
     margin: 0 1rem 1rem;
     text-transform: uppercase;
@@ -373,7 +373,7 @@ h1 span:nth-of-type(11) {
     margin-bottom: 2px;
     line-height: 2; }
     .effeckt-list li.new-item {
-      background: #ccc; }
+      background: #cccccc; }
 
 .effeckt-list-scroll {
   width: 230px;
@@ -385,7 +385,7 @@ h1 span:nth-of-type(11) {
   list-style: none; }
   .effeckt-list-scroll > li {
     padding: 0.5rem;
-    background: #eee;
+    background: #eeeeee;
     color: #252525;
     font-size: 18px; }
     .effeckt-list-scroll > li:nth-child(odd) {

--- a/dist/assets/css/effeckt.autoprefixed.css
+++ b/dist/assets/css/effeckt.autoprefixed.css
@@ -1447,9 +1447,9 @@
   -ms-transform: translateY(-100%);
   -o-transform: translateY(-100%);
   transform: translateY(-100%);
-  -webkit-transition: all .3s;
-  -o-transition: all .3s;
-  transition: all .3s;
+  -webkit-transition: all 0.3s;
+  -o-transition: all 0.3s;
+  transition: all 0.3s;
   opacity: 0;
 }
 
@@ -1572,11 +1572,11 @@
 
 .effeckt-show.md-effect-12 .effeckt-modal {
   opacity: 1;
-  background: #555;
+  background: #555555;
 }
 
 .effeckt-show.md-effect-12 ~ .effeckt-overlay {
-  background: #555;
+  background: #555555;
 }
 
 .md-effect-12,
@@ -3631,15 +3631,15 @@
   position: relative;
 }
 
-.effeckt-tooltip-1[data-effeckt-tooltip-text]::before,
-.effeckt-tooltip-1[data-effeckt-tooltip-text]::after {
+.effeckt-tooltip-top[data-effeckt-tooltip-text]::before,
+.effeckt-tooltip-top[data-effeckt-tooltip-text]::after {
   opacity: 0;
   -webkit-transition: 0.2s;
   -o-transition: 0.2s;
   transition: 0.2s;
 }
 
-.effeckt-tooltip-1[data-effeckt-tooltip-text]::after {
+.effeckt-tooltip-top[data-effeckt-tooltip-text]::after {
   content: attr(data-effeckt-tooltip-text);
   position: absolute;
   left: 50%;
@@ -3647,9 +3647,8 @@
   -ms-transform: translateX(-50%);
   -o-transform: translateX(-50%);
   transform: translateX(-50%);
-  bottom: 125%;
   border-radius: 10px;
-  background: #333;
+  background: #333333;
   color: white;
   padding: 0.45rem 0.8rem;
   font-size: 90%;
@@ -3657,40 +3656,50 @@
   visibility: hidden;
 }
 
-.effeckt-tooltip-1[data-effeckt-tooltip-text]::before {
+.effeckt-tooltip-top[data-effeckt-tooltip-text]::before {
   content: "";
   width: 0;
   height: 0;
-  border-top: 5px solid #333;
   border-left: 5px solid transparent;
   border-right: 5px solid transparent;
   position: absolute;
+  left: 50%;
+  margin-left: -5px;
+}
+
+.effeckt-tooltip-top[data-effeckt-tooltip-text]:hover::before,
+.effeckt-tooltip-top[data-effeckt-tooltip-text]:hover::after {
+  visibility: visible;
+  opacity: 1;
+  -webkit-transition: 0.2s 0.3s;
+  -o-transition: 0.2s 0.3s;
+  transition: 0.2s 0.3s;
+}
+
+.effeckt-tooltip-top[data-effeckt-tooltip-text]::after {
+  bottom: 125%;
+}
+
+.effeckt-tooltip-top[data-effeckt-tooltip-text]::before {
+  border-top: 5px solid #333333;
   bottom: 125%;
   margin-bottom: -4px;
-  left: 50%;
-  margin-left: -5px;
 }
 
-.effeckt-tooltip-1[data-effeckt-tooltip-text]:hover::before,
-.effeckt-tooltip-1[data-effeckt-tooltip-text]:hover::after {
-  visibility: visible;
-  opacity: 1;
+.effeckt-tooltip-top[data-effeckt-tooltip-text]:hover::before,
+.effeckt-tooltip-top[data-effeckt-tooltip-text]:hover::after {
   bottom: 115%;
-  -webkit-transition: 0.2s 0.3s;
-  -o-transition: 0.2s 0.3s;
-  transition: 0.2s 0.3s;
 }
 
-.effeckt-tooltip-2[data-effeckt-tooltip-text]::before,
-.effeckt-tooltip-2[data-effeckt-tooltip-text]::after {
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]::before,
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]::after {
   opacity: 0;
-  visibility: hidden;
   -webkit-transition: 0.2s;
   -o-transition: 0.2s;
   transition: 0.2s;
 }
 
-.effeckt-tooltip-2[data-effeckt-tooltip-text]::after {
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]::after {
   content: attr(data-effeckt-tooltip-text);
   position: absolute;
   left: 50%;
@@ -3698,35 +3707,46 @@
   -ms-transform: translateX(-50%);
   -o-transform: translateX(-50%);
   transform: translateX(-50%);
-  top: 125%;
   border-radius: 10px;
-  background: #333;
+  background: #333333;
   color: white;
   padding: 0.45rem 0.8rem;
   font-size: 90%;
   white-space: nowrap;
+  visibility: hidden;
 }
 
-.effeckt-tooltip-2[data-effeckt-tooltip-text]::before {
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]::before {
   content: "";
   width: 0;
   height: 0;
-  border-bottom: 5px solid #333;
   border-left: 5px solid transparent;
   border-right: 5px solid transparent;
   position: absolute;
-  top: 125%;
-  margin-top: -4px;
   left: 50%;
   margin-left: -5px;
 }
 
-.effeckt-tooltip-2[data-effeckt-tooltip-text]:hover::before,
-.effeckt-tooltip-2[data-effeckt-tooltip-text]:hover::after {
-  opacity: 1;
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]:hover::before,
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]:hover::after {
   visibility: visible;
-  top: 115%;
+  opacity: 1;
   -webkit-transition: 0.2s 0.3s;
   -o-transition: 0.2s 0.3s;
   transition: 0.2s 0.3s;
+}
+
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]::after {
+  top: 125%;
+}
+
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]::before {
+  border-bottom: 5px solid #333333;
+  top: 125%;
+  margin-top: -4px;
+}
+
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]:hover::before,
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]:hover::after {
+  top: 115%;
 }

--- a/dist/assets/css/effeckt.css
+++ b/dist/assets/css/effeckt.css
@@ -625,7 +625,7 @@
 
 .md-effect-7 .effeckt-modal {
   transform: translateY(-100%);
-  transition: all .3s;
+  transition: all 0.3s;
   opacity: 0; }
 
 .effeckt-show.md-effect-7 .effeckt-modal {
@@ -682,10 +682,10 @@
 
 .effeckt-show.md-effect-12 .effeckt-modal {
   opacity: 1;
-  background: #555; }
+  background: #555555; }
 
 .effeckt-show.md-effect-12 ~ .effeckt-overlay {
-  background: #555; }
+  background: #555555; }
 
 .md-effect-12, .md-effect-12 h3 {
   background: transparent; }
@@ -1316,70 +1316,76 @@
 [data-effeckt-tooltip-text] {
   position: relative; }
 
-.effeckt-tooltip-1[data-effeckt-tooltip-text]::before, .effeckt-tooltip-1[data-effeckt-tooltip-text]::after {
+.effeckt-tooltip-top[data-effeckt-tooltip-text]::before, .effeckt-tooltip-top[data-effeckt-tooltip-text]::after {
   opacity: 0;
   transition: 0.2s; }
-.effeckt-tooltip-1[data-effeckt-tooltip-text]::after {
+.effeckt-tooltip-top[data-effeckt-tooltip-text]::after {
   content: attr(data-effeckt-tooltip-text);
   position: absolute;
   left: 50%;
   transform: translateX(-50%);
-  bottom: 125%;
   border-radius: 10px;
-  background: #333;
+  background: #333333;
   color: white;
   padding: 0.45rem 0.8rem;
   font-size: 90%;
   white-space: nowrap;
   visibility: hidden; }
-.effeckt-tooltip-1[data-effeckt-tooltip-text]::before {
+.effeckt-tooltip-top[data-effeckt-tooltip-text]::before {
   content: "";
   width: 0;
   height: 0;
-  border-top: 5px solid #333;
   border-left: 5px solid transparent;
   border-right: 5px solid transparent;
   position: absolute;
-  bottom: 125%;
-  margin-bottom: -4px;
   left: 50%;
   margin-left: -5px; }
-.effeckt-tooltip-1[data-effeckt-tooltip-text]:hover::before, .effeckt-tooltip-1[data-effeckt-tooltip-text]:hover::after {
+.effeckt-tooltip-top[data-effeckt-tooltip-text]:hover::before, .effeckt-tooltip-top[data-effeckt-tooltip-text]:hover::after {
   visibility: visible;
   opacity: 1;
-  bottom: 115%;
   transition: 0.2s 0.3s; }
+.effeckt-tooltip-top[data-effeckt-tooltip-text]::after {
+  bottom: 125%; }
+.effeckt-tooltip-top[data-effeckt-tooltip-text]::before {
+  border-top: 5px solid #333333;
+  bottom: 125%;
+  margin-bottom: -4px; }
+.effeckt-tooltip-top[data-effeckt-tooltip-text]:hover::before, .effeckt-tooltip-top[data-effeckt-tooltip-text]:hover::after {
+  bottom: 115%; }
 
-.effeckt-tooltip-2[data-effeckt-tooltip-text]::before, .effeckt-tooltip-2[data-effeckt-tooltip-text]::after {
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]::before, .effeckt-tooltip-bottom[data-effeckt-tooltip-text]::after {
   opacity: 0;
-  visibility: hidden;
   transition: 0.2s; }
-.effeckt-tooltip-2[data-effeckt-tooltip-text]::after {
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]::after {
   content: attr(data-effeckt-tooltip-text);
   position: absolute;
   left: 50%;
   transform: translateX(-50%);
-  top: 125%;
   border-radius: 10px;
-  background: #333;
+  background: #333333;
   color: white;
   padding: 0.45rem 0.8rem;
   font-size: 90%;
-  white-space: nowrap; }
-.effeckt-tooltip-2[data-effeckt-tooltip-text]::before {
+  white-space: nowrap;
+  visibility: hidden; }
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]::before {
   content: "";
   width: 0;
   height: 0;
-  border-bottom: 5px solid #333;
   border-left: 5px solid transparent;
   border-right: 5px solid transparent;
   position: absolute;
-  top: 125%;
-  margin-top: -4px;
   left: 50%;
   margin-left: -5px; }
-.effeckt-tooltip-2[data-effeckt-tooltip-text]:hover::before, .effeckt-tooltip-2[data-effeckt-tooltip-text]:hover::after {
-  opacity: 1;
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]:hover::before, .effeckt-tooltip-bottom[data-effeckt-tooltip-text]:hover::after {
   visibility: visible;
-  top: 115%;
+  opacity: 1;
   transition: 0.2s 0.3s; }
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]::after {
+  top: 125%; }
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]::before {
+  border-bottom: 5px solid #333333;
+  top: 125%;
+  margin-top: -4px; }
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]:hover::before, .effeckt-tooltip-bottom[data-effeckt-tooltip-text]:hover::after {
+  top: 115%; }

--- a/dist/assets/css/modules/modals.autoprefixed.css
+++ b/dist/assets/css/modules/modals.autoprefixed.css
@@ -215,9 +215,9 @@
   -ms-transform: translateY(-100%);
   -o-transform: translateY(-100%);
   transform: translateY(-100%);
-  -webkit-transition: all .3s;
-  -o-transition: all .3s;
-  transition: all .3s;
+  -webkit-transition: all 0.3s;
+  -o-transition: all 0.3s;
+  transition: all 0.3s;
   opacity: 0;
 }
 
@@ -340,11 +340,11 @@
 
 .effeckt-show.md-effect-12 .effeckt-modal {
   opacity: 1;
-  background: #555;
+  background: #555555;
 }
 
 .effeckt-show.md-effect-12 ~ .effeckt-overlay {
-  background: #555;
+  background: #555555;
 }
 
 .md-effect-12,

--- a/dist/assets/css/modules/modals.css
+++ b/dist/assets/css/modules/modals.css
@@ -114,7 +114,7 @@
 
 .md-effect-7 .effeckt-modal {
   transform: translateY(-100%);
-  transition: all .3s;
+  transition: all 0.3s;
   opacity: 0; }
 
 .effeckt-show.md-effect-7 .effeckt-modal {
@@ -171,10 +171,10 @@
 
 .effeckt-show.md-effect-12 .effeckt-modal {
   opacity: 1;
-  background: #555; }
+  background: #555555; }
 
 .effeckt-show.md-effect-12 ~ .effeckt-overlay {
-  background: #555; }
+  background: #555555; }
 
 .md-effect-12, .md-effect-12 h3 {
   background: transparent; }

--- a/dist/assets/css/modules/tooltips.autoprefixed.css
+++ b/dist/assets/css/modules/tooltips.autoprefixed.css
@@ -2,15 +2,15 @@
   position: relative;
 }
 
-.effeckt-tooltip-1[data-effeckt-tooltip-text]::before,
-.effeckt-tooltip-1[data-effeckt-tooltip-text]::after {
+.effeckt-tooltip-top[data-effeckt-tooltip-text]::before,
+.effeckt-tooltip-top[data-effeckt-tooltip-text]::after {
   opacity: 0;
   -webkit-transition: 0.2s;
   -o-transition: 0.2s;
   transition: 0.2s;
 }
 
-.effeckt-tooltip-1[data-effeckt-tooltip-text]::after {
+.effeckt-tooltip-top[data-effeckt-tooltip-text]::after {
   content: attr(data-effeckt-tooltip-text);
   position: absolute;
   left: 50%;
@@ -18,9 +18,8 @@
   -ms-transform: translateX(-50%);
   -o-transform: translateX(-50%);
   transform: translateX(-50%);
-  bottom: 125%;
   border-radius: 10px;
-  background: #333;
+  background: #333333;
   color: white;
   padding: 0.45rem 0.8rem;
   font-size: 90%;
@@ -28,40 +27,50 @@
   visibility: hidden;
 }
 
-.effeckt-tooltip-1[data-effeckt-tooltip-text]::before {
+.effeckt-tooltip-top[data-effeckt-tooltip-text]::before {
   content: "";
   width: 0;
   height: 0;
-  border-top: 5px solid #333;
   border-left: 5px solid transparent;
   border-right: 5px solid transparent;
   position: absolute;
+  left: 50%;
+  margin-left: -5px;
+}
+
+.effeckt-tooltip-top[data-effeckt-tooltip-text]:hover::before,
+.effeckt-tooltip-top[data-effeckt-tooltip-text]:hover::after {
+  visibility: visible;
+  opacity: 1;
+  -webkit-transition: 0.2s 0.3s;
+  -o-transition: 0.2s 0.3s;
+  transition: 0.2s 0.3s;
+}
+
+.effeckt-tooltip-top[data-effeckt-tooltip-text]::after {
+  bottom: 125%;
+}
+
+.effeckt-tooltip-top[data-effeckt-tooltip-text]::before {
+  border-top: 5px solid #333333;
   bottom: 125%;
   margin-bottom: -4px;
-  left: 50%;
-  margin-left: -5px;
 }
 
-.effeckt-tooltip-1[data-effeckt-tooltip-text]:hover::before,
-.effeckt-tooltip-1[data-effeckt-tooltip-text]:hover::after {
-  visibility: visible;
-  opacity: 1;
+.effeckt-tooltip-top[data-effeckt-tooltip-text]:hover::before,
+.effeckt-tooltip-top[data-effeckt-tooltip-text]:hover::after {
   bottom: 115%;
-  -webkit-transition: 0.2s 0.3s;
-  -o-transition: 0.2s 0.3s;
-  transition: 0.2s 0.3s;
 }
 
-.effeckt-tooltip-2[data-effeckt-tooltip-text]::before,
-.effeckt-tooltip-2[data-effeckt-tooltip-text]::after {
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]::before,
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]::after {
   opacity: 0;
-  visibility: hidden;
   -webkit-transition: 0.2s;
   -o-transition: 0.2s;
   transition: 0.2s;
 }
 
-.effeckt-tooltip-2[data-effeckt-tooltip-text]::after {
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]::after {
   content: attr(data-effeckt-tooltip-text);
   position: absolute;
   left: 50%;
@@ -69,35 +78,46 @@
   -ms-transform: translateX(-50%);
   -o-transform: translateX(-50%);
   transform: translateX(-50%);
-  top: 125%;
   border-radius: 10px;
-  background: #333;
+  background: #333333;
   color: white;
   padding: 0.45rem 0.8rem;
   font-size: 90%;
   white-space: nowrap;
+  visibility: hidden;
 }
 
-.effeckt-tooltip-2[data-effeckt-tooltip-text]::before {
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]::before {
   content: "";
   width: 0;
   height: 0;
-  border-bottom: 5px solid #333;
   border-left: 5px solid transparent;
   border-right: 5px solid transparent;
   position: absolute;
-  top: 125%;
-  margin-top: -4px;
   left: 50%;
   margin-left: -5px;
 }
 
-.effeckt-tooltip-2[data-effeckt-tooltip-text]:hover::before,
-.effeckt-tooltip-2[data-effeckt-tooltip-text]:hover::after {
-  opacity: 1;
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]:hover::before,
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]:hover::after {
   visibility: visible;
-  top: 115%;
+  opacity: 1;
   -webkit-transition: 0.2s 0.3s;
   -o-transition: 0.2s 0.3s;
   transition: 0.2s 0.3s;
+}
+
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]::after {
+  top: 125%;
+}
+
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]::before {
+  border-bottom: 5px solid #333333;
+  top: 125%;
+  margin-top: -4px;
+}
+
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]:hover::before,
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]:hover::after {
+  top: 115%;
 }

--- a/dist/assets/css/modules/tooltips.css
+++ b/dist/assets/css/modules/tooltips.css
@@ -1,70 +1,76 @@
 [data-effeckt-tooltip-text] {
   position: relative; }
 
-.effeckt-tooltip-1[data-effeckt-tooltip-text]::before, .effeckt-tooltip-1[data-effeckt-tooltip-text]::after {
+.effeckt-tooltip-top[data-effeckt-tooltip-text]::before, .effeckt-tooltip-top[data-effeckt-tooltip-text]::after {
   opacity: 0;
   transition: 0.2s; }
-.effeckt-tooltip-1[data-effeckt-tooltip-text]::after {
+.effeckt-tooltip-top[data-effeckt-tooltip-text]::after {
   content: attr(data-effeckt-tooltip-text);
   position: absolute;
   left: 50%;
   transform: translateX(-50%);
-  bottom: 125%;
   border-radius: 10px;
-  background: #333;
+  background: #333333;
   color: white;
   padding: 0.45rem 0.8rem;
   font-size: 90%;
   white-space: nowrap;
   visibility: hidden; }
-.effeckt-tooltip-1[data-effeckt-tooltip-text]::before {
+.effeckt-tooltip-top[data-effeckt-tooltip-text]::before {
   content: "";
   width: 0;
   height: 0;
-  border-top: 5px solid #333;
   border-left: 5px solid transparent;
   border-right: 5px solid transparent;
   position: absolute;
-  bottom: 125%;
-  margin-bottom: -4px;
   left: 50%;
   margin-left: -5px; }
-.effeckt-tooltip-1[data-effeckt-tooltip-text]:hover::before, .effeckt-tooltip-1[data-effeckt-tooltip-text]:hover::after {
+.effeckt-tooltip-top[data-effeckt-tooltip-text]:hover::before, .effeckt-tooltip-top[data-effeckt-tooltip-text]:hover::after {
   visibility: visible;
   opacity: 1;
-  bottom: 115%;
   transition: 0.2s 0.3s; }
+.effeckt-tooltip-top[data-effeckt-tooltip-text]::after {
+  bottom: 125%; }
+.effeckt-tooltip-top[data-effeckt-tooltip-text]::before {
+  border-top: 5px solid #333333;
+  bottom: 125%;
+  margin-bottom: -4px; }
+.effeckt-tooltip-top[data-effeckt-tooltip-text]:hover::before, .effeckt-tooltip-top[data-effeckt-tooltip-text]:hover::after {
+  bottom: 115%; }
 
-.effeckt-tooltip-2[data-effeckt-tooltip-text]::before, .effeckt-tooltip-2[data-effeckt-tooltip-text]::after {
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]::before, .effeckt-tooltip-bottom[data-effeckt-tooltip-text]::after {
   opacity: 0;
-  visibility: hidden;
   transition: 0.2s; }
-.effeckt-tooltip-2[data-effeckt-tooltip-text]::after {
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]::after {
   content: attr(data-effeckt-tooltip-text);
   position: absolute;
   left: 50%;
   transform: translateX(-50%);
-  top: 125%;
   border-radius: 10px;
-  background: #333;
+  background: #333333;
   color: white;
   padding: 0.45rem 0.8rem;
   font-size: 90%;
-  white-space: nowrap; }
-.effeckt-tooltip-2[data-effeckt-tooltip-text]::before {
+  white-space: nowrap;
+  visibility: hidden; }
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]::before {
   content: "";
   width: 0;
   height: 0;
-  border-bottom: 5px solid #333;
   border-left: 5px solid transparent;
   border-right: 5px solid transparent;
   position: absolute;
-  top: 125%;
-  margin-top: -4px;
   left: 50%;
   margin-left: -5px; }
-.effeckt-tooltip-2[data-effeckt-tooltip-text]:hover::before, .effeckt-tooltip-2[data-effeckt-tooltip-text]:hover::after {
-  opacity: 1;
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]:hover::before, .effeckt-tooltip-bottom[data-effeckt-tooltip-text]:hover::after {
   visibility: visible;
-  top: 115%;
+  opacity: 1;
   transition: 0.2s 0.3s; }
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]::after {
+  top: 125%; }
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]::before {
+  border-bottom: 5px solid #333333;
+  top: 125%;
+  margin-top: -4px; }
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text]:hover::before, .effeckt-tooltip-bottom[data-effeckt-tooltip-text]:hover::after {
+  top: 115%; }

--- a/dist/index.html
+++ b/dist/index.html
@@ -476,7 +476,7 @@
     </span> -->
   </header>
 
-  <p>Lorem ipsum <a href="#0" data-effeckt-tooltip-text="I appear on top." class="effeckt-tooltip-1">example one</a> dolor sit amet, consectetur adipisicing elit. Unde, dolor, <a href="#0" data-effeckt-tooltip-text="I appear on bottom." class="effeckt-tooltip-2">example two</a> ipsa, dolorem officia expedita error vel blanditiis tempore molestias voluptatem ducimus porro recusandae quo ex quisquam voluptas iure! Amet, dignissimos.</p>
+  <p>Lorem ipsum <a href="#0" data-effeckt-tooltip-text="I appear on top." class="effeckt-tooltip-top">example one</a> dolor sit amet, consectetur adipisicing elit. Unde, dolor, <a href="#0" data-effeckt-tooltip-text="I appear on bottom." class="effeckt-tooltip-bottom">example two</a> ipsa, dolorem officia expedita error vel blanditiis tempore molestias voluptatem ducimus porro recusandae quo ex quisquam voluptas iure! Amet, dignissimos.</p>
 
 </div>
 

--- a/dist/tooltips.html
+++ b/dist/tooltips.html
@@ -105,7 +105,7 @@
     </span> -->
   </header>
 
-  <p>Lorem ipsum <a href="#0" data-effeckt-tooltip-text="I appear on top." class="effeckt-tooltip-1">example one</a> dolor sit amet, consectetur adipisicing elit. Unde, dolor, <a href="#0" data-effeckt-tooltip-text="I appear on bottom." class="effeckt-tooltip-2">example two</a> ipsa, dolorem officia expedita error vel blanditiis tempore molestias voluptatem ducimus porro recusandae quo ex quisquam voluptas iure! Amet, dignissimos.</p>
+  <p>Lorem ipsum <a href="#0" data-effeckt-tooltip-text="I appear on top." class="effeckt-tooltip-top">example one</a> dolor sit amet, consectetur adipisicing elit. Unde, dolor, <a href="#0" data-effeckt-tooltip-text="I appear on bottom." class="effeckt-tooltip-bottom">example two</a> ipsa, dolorem officia expedita error vel blanditiis tempore molestias voluptatem ducimus porro recusandae quo ex quisquam voluptas iure! Amet, dignissimos.</p>
 
 </div>
  

--- a/scss/modules/tooltips.scss
+++ b/scss/modules/tooltips.scss
@@ -2,83 +2,80 @@
   position: relative;
 }
 
-// probably should make various things into variables, like colors
-.effeckt-tooltip-1[data-effeckt-tooltip-text] {
+@mixin effeckt-tooltip($direction, $background: #333, $color: white) {
   &::before, &::after {
     opacity: 0;
     transition: 0.2s; // no delay on hover off
   }
+
   &::after { // text of tooltip
     content: attr(data-effeckt-tooltip-text);
     position: absolute;
     left: 50%;
     transform: translateX(-50%); // horizontal centering
-    bottom: 125%;
     border-radius: 10px;
-    background: #333;
-    color: white;
+    background: $background;
+    color: $color;
     padding: 0.45rem 0.8rem;
     font-size: 90%;
     white-space: nowrap;
     visibility: hidden;
   }
+
   &::before { // triangle / speech bubble arrow
     content: "";
     width: 0;
     height: 0;
-    border-top: 5px solid #333;
     border-left: 5px solid transparent;
     border-right: 5px solid transparent;
     position: absolute;
-    bottom: 125%;
-    margin-bottom: -4px; // one less pixel to prevent occational 1px gap
     left: 50%;
     margin-left: -5px;
   }
+
   &:hover::before, &:hover::after {
     visibility: visible;
     opacity: 1;
-    bottom: 115%;
     transition: 0.2s 0.3s; // slight delay on hover on
+  }
+
+  // direction specific
+  @if $direction == bottom {
+    &::after { // text of tooltip
+      top: 125%;
+    }
+
+    &::before {
+      border-bottom: 5px solid $background;
+      top: 125%;
+      margin-top: -4px; // one less pixel to prevent occational 1px gap
+    }
+
+    &:hover::before, &:hover::after {
+      top: 115%;
+    }
+  } @else {
+    &::after {
+      bottom: 125%;
+    }
+
+    &::before {
+      border-top: 5px solid $background;
+      bottom: 125%;
+      margin-bottom: -4px; // one less pixel to prevent occational 1px gap
+    }
+
+    &:hover::before, &:hover::after {
+      bottom: 115%;
+    }
   }
 }
 
-.effeckt-tooltip-2[data-effeckt-tooltip-text] {
-  &::before, &::after {
-    opacity: 0;
-    visibility: hidden;
-    transition: 0.2s; // no delay on hover off
-  }
-  &::after { // text of tooltip
-    content: attr(data-effeckt-tooltip-text);
-    position: absolute;
-    left: 50%;
-    transform: translateX(-50%); // horizontal centering
-    top: 125%;
-    border-radius: 10px;
-    background: #333;
-    color: white;
-    padding: 0.45rem 0.8rem;
-    font-size: 90%;
-    white-space: nowrap;
-  }
-  &::before { // triangle / speech bubble arrow
-    content: "";
-    width: 0;
-    height: 0;
-    border-bottom: 5px solid #333;
-    border-left: 5px solid transparent;
-    border-right: 5px solid transparent;
-    position: absolute;
-    top: 125%;
-    margin-top: -4px; // one less pixel to prevent occational 1px gap
-    left: 50%;
-    margin-left: -5px;
-  }
-  &:hover::before, &:hover::after {
-    opacity: 1;
-    visibility: visible;
-    top: 115%;
-    transition: 0.2s 0.3s; // slight delay on hover on
-  }
+// probably should make various things into variables, like colors
+.effeckt-tooltip-top[data-effeckt-tooltip-text] {
+  @include effeckt-tooltip(top);
+}
+
+.effeckt-tooltip-bottom[data-effeckt-tooltip-text] {
+  @include effeckt-tooltip(bottom);
 }

--- a/src/templates/pages/tooltips.hbs
+++ b/src/templates/pages/tooltips.hbs
@@ -10,6 +10,6 @@
     </span> -->
   </header>
 
-  <p>Lorem ipsum <a href="#0" data-effeckt-tooltip-text="I appear on top." class="effeckt-tooltip-1">example one</a> dolor sit amet, consectetur adipisicing elit. Unde, dolor, <a href="#0" data-effeckt-tooltip-text="I appear on bottom." class="effeckt-tooltip-2">example two</a> ipsa, dolorem officia expedita error vel blanditiis tempore molestias voluptatem ducimus porro recusandae quo ex quisquam voluptas iure! Amet, dignissimos.</p>
+  <p>Lorem ipsum <a href="#0" data-effeckt-tooltip-text="I appear on top." class="effeckt-tooltip-top">example one</a> dolor sit amet, consectetur adipisicing elit. Unde, dolor, <a href="#0" data-effeckt-tooltip-text="I appear on bottom." class="effeckt-tooltip-bottom">example two</a> ipsa, dolorem officia expedita error vel blanditiis tempore molestias voluptatem ducimus porro recusandae quo ex quisquam voluptas iure! Amet, dignissimos.</p>
 
 </div>


### PR DESCRIPTION
You can now provide direction (top/bottom) and colours directly to the mixin.

Unfortunately, I'm getting the same Sass compiling problem that @chriscoyier had. If anyone has an idea on how to fix it, I'll gladly close this pull request and open up a cleaner one.
