### PR TITLE
Applied class/data-attribute naming convention to icon-slide buttons.

### DIFF
--- a/css/effeckt.autoprefixed.css
+++ b/css/effeckt.autoprefixed.css
@@ -347,24 +347,26 @@
   z-index: 1;
 }
 
-/* The effeckt-button--icon-slide__icon--demo data-URI and class are for demo purposes.
-A user could apply their own class to the button's label to designate
-the icon/image they want sliding in and out -- utilizing the :before
-pseudo-element to place a background image or character from an icon
-font. */
+/*==========================
+ICON SLIDE
 
-.effeckt-button--icon-slide__icon--demo:before {
-  content: '';
+Example markup:
+<button class="effeckt-button" data-effeckt-type="icon-slide from-top">
+  <span class="effeckt-button-label demo-button-icon">Icon from top</span>
+</button>
+==========================*/
+
+.demo-button-icon:before {
   background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPCEtLSBHZW5lcmF0b3I6IEljb01vb24uaW8gLS0+IDwhRE9DVFlQRSBzdmcgUFVCTElDICItLy9XM0MvL0RURCBTVkcgMS4xLy9FTiIgImh0dHA6Ly93d3cudzMub3JnL0dyYXBoaWNzL1NWRy8xLjEvRFREL3N2ZzExLmR0ZCI+IDxzdmcgd2lkdGg9IjMyIiBoZWlnaHQ9IjMyIiB2aWV3Qm94PSIwIDAgMzIgMzIiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIGZpbGw9IiNmZmZmZmYiPjxnPjxwYXRoIGQ9Ik0gMTYsMyBDIDEyLjUyOCwzIDkuMjYzLDQuMzUyIDYuODA4LDYuODA4IEMgNC4zNTIsOS4yNjMgMywxMi41MjggMywxNiBDIDMsMTkuNDcyIDQuMzUyLDIyLjczNyA2LjgwOCwyNS4xOTIgQyA5LjI2MywyNy42NDggMTIuNTI4LDI5IDE2LDI5IEMgMTkuNDcyLDI5IDIyLjczNywyNy42NDggMjUuMTkyLDI1LjE5MiBDIDI3LjY0OCwyMi43MzcgMjksMTkuNDcyIDI5LDE2IEMgMjksMTIuNTI4IDI3LjY0OCw5LjI2MyAyNS4xOTIsNi44MDggQyAyMi43MzcsNC4zNTIgMTkuNDcyLDMgMTYsMyBaIE0gMTYsMCBMIDE2LDAgQyAyNC44MzcsMCAzMiw3LjE2MyAzMiwxNiBDIDMyLDI0LjgzNyAyNC44MzcsMzIgMTYsMzIgQyA3LjE2MywzMiAwLDI0LjgzNyAwLDE2IEMgMCw3LjE2MyA3LjE2MywwIDE2LDAgWk0gMTQsMjJMIDE4LDIyTCAxOCwyNkwgMTQsMjZ6TSAxNCw2TCAxOCw2TCAxOCwxOEwgMTQsMTh6Ij48L3BhdGg+PC9nPjwvc3ZnPg==) no-repeat center center;
-  background-size: 30px 30px;
+  background-size: 30px 100%;
 }
 
-.effeckt-button--icon-slide {
+.effeckt-button[data-effeckt-type~="icon-slide"] {
   overflow: hidden;
   padding: 0;
 }
 
-.effeckt-button--icon-slide__label {
+.effeckt-button[data-effeckt-type~="icon-slide"] .effeckt-button-label {
   padding: 0.8rem 1rem;
   display: block;
   position: relative;
@@ -374,63 +376,60 @@ font. */
   transition: transform 500ms;
 }
 
-.effeckt-button--icon-slide__label:before {
+.effeckt-button[data-effeckt-type~="icon-slide"] .effeckt-button-label:before {
+  content: '';
   display: block;
   position: absolute;
   width: 100%;
   height: 100%;
 }
 
-.effeckt-button--icon-slide--from-top .effeckt-button--icon-slide__label:before {
+.effeckt-button[data-effeckt-type~="icon-slide"][data-effeckt-type~="from-top"] .effeckt-button-label:before {
   top: -100%;
-}
-
-.effeckt-button--icon-slide--from-bottom .effeckt-button--icon-slide__label:before {
-  bottom: -100%;
-}
-
-.effeckt-button--icon-slide--from-left .effeckt-button--icon-slide__label:before {
-  left: -100%;
-}
-
-.effeckt-button--icon-slide--from-right .effeckt-button--icon-slide__label:before {
-  right: -100%;
-}
-
-.effeckt-button--icon-slide--from-top .effeckt-button--icon-slide__label:before,
-.effeckt-button--icon-slide--from-bottom .effeckt-button--icon-slide__label:before {
   left: 0;
   right: 0;
 }
 
-.effeckt-button--icon-slide--from-left .effeckt-button--icon-slide__label:before,
-.effeckt-button--icon-slide--from-right .effeckt-button--icon-slide__label:before {
+.effeckt-button[data-effeckt-type~="icon-slide"][data-effeckt-type~="from-bottom"] .effeckt-button-label:before {
+  bottom: -100%;
+  left: 0;
+  right: 0;
+}
+
+.effeckt-button[data-effeckt-type~="icon-slide"][data-effeckt-type~="from-left"] .effeckt-button-label:before {
+  left: -100%;
   top: 0;
   bottom: 0;
 }
 
-.effeckt-button--icon-slide:hover.effeckt-button--icon-slide--from-top .effeckt-button--icon-slide__label {
+.effeckt-button[data-effeckt-type~="icon-slide"][data-effeckt-type~="from-right"] .effeckt-button-label:before {
+  right: -100%;
+  top: 0;
+  bottom: 0;
+}
+
+.effeckt-button[data-effeckt-type~="icon-slide"]:hover[data-effeckt-type~="from-top"] .effeckt-button-label {
   -webkit-transform: translateY(100%);
   -ms-transform: translateY(100%);
   -o-transform: translateY(100%);
   transform: translateY(100%);
 }
 
-.effeckt-button--icon-slide:hover.effeckt-button--icon-slide--from-bottom .effeckt-button--icon-slide__label {
+.effeckt-button[data-effeckt-type~="icon-slide"]:hover[data-effeckt-type~="from-bottom"] .effeckt-button-label {
   -webkit-transform: translateY(-100%);
   -ms-transform: translateY(-100%);
   -o-transform: translateY(-100%);
   transform: translateY(-100%);
 }
 
-.effeckt-button--icon-slide:hover.effeckt-button--icon-slide--from-left .effeckt-button--icon-slide__label {
+.effeckt-button[data-effeckt-type~="icon-slide"]:hover[data-effeckt-type~="from-left"] .effeckt-button-label {
   -webkit-transform: translateX(100%);
   -ms-transform: translateX(100%);
   -o-transform: translateX(100%);
   transform: translateX(100%);
 }
 
-.effeckt-button--icon-slide:hover.effeckt-button--icon-slide--from-right .effeckt-button--icon-slide__label {
+.effeckt-button[data-effeckt-type~="icon-slide"]:hover[data-effeckt-type~="from-right"] .effeckt-button-label {
   -webkit-transform: translateX(-100%);
   -ms-transform: translateX(-100%);
   -o-transform: translateX(-100%);

--- a/css/effeckt.css
+++ b/css/effeckt.css
@@ -241,58 +241,57 @@
   position: relative;
   z-index: 1; }
 
-/* The effeckt-button--icon-slide__icon--demo data-URI and class are for demo purposes.
-A user could apply their own class to the button's label to designate
-the icon/image they want sliding in and out -- utilizing the :before
-pseudo-element to place a background image or character from an icon
-font. */
-.effeckt-button--icon-slide__icon--demo:before {
-  content: '';
-  background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPCEtLSBHZW5lcmF0b3I6IEljb01vb24uaW8gLS0+IDwhRE9DVFlQRSBzdmcgUFVCTElDICItLy9XM0MvL0RURCBTVkcgMS4xLy9FTiIgImh0dHA6Ly93d3cudzMub3JnL0dyYXBoaWNzL1NWRy8xLjEvRFREL3N2ZzExLmR0ZCI+IDxzdmcgd2lkdGg9IjMyIiBoZWlnaHQ9IjMyIiB2aWV3Qm94PSIwIDAgMzIgMzIiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIGZpbGw9IiNmZmZmZmYiPjxnPjxwYXRoIGQ9Ik0gMTYsMyBDIDEyLjUyOCwzIDkuMjYzLDQuMzUyIDYuODA4LDYuODA4IEMgNC4zNTIsOS4yNjMgMywxMi41MjggMywxNiBDIDMsMTkuNDcyIDQuMzUyLDIyLjczNyA2LjgwOCwyNS4xOTIgQyA5LjI2MywyNy42NDggMTIuNTI4LDI5IDE2LDI5IEMgMTkuNDcyLDI5IDIyLjczNywyNy42NDggMjUuMTkyLDI1LjE5MiBDIDI3LjY0OCwyMi43MzcgMjksMTkuNDcyIDI5LDE2IEMgMjksMTIuNTI4IDI3LjY0OCw5LjI2MyAyNS4xOTIsNi44MDggQyAyMi43MzcsNC4zNTIgMTkuNDcyLDMgMTYsMyBaIE0gMTYsMCBMIDE2LDAgQyAyNC44MzcsMCAzMiw3LjE2MyAzMiwxNiBDIDMyLDI0LjgzNyAyNC44MzcsMzIgMTYsMzIgQyA3LjE2MywzMiAwLDI0LjgzNyAwLDE2IEMgMCw3LjE2MyA3LjE2MywwIDE2LDAgWk0gMTQsMjJMIDE4LDIyTCAxOCwyNkwgMTQsMjZ6TSAxNCw2TCAxOCw2TCAxOCwxOEwgMTQsMTh6Ij48L3BhdGg+PC9nPjwvc3ZnPg==) no-repeat center center;
-  background-size: 30px 30px; }
+/*==========================
+ICON SLIDE
 
-.effeckt-button--icon-slide {
+Example markup:
+<button class="effeckt-button" data-effeckt-type="icon-slide from-top">
+  <span class="effeckt-button-label demo-button-icon">Icon from top</span>
+</button>
+==========================*/
+.demo-button-icon:before {
+  background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPCEtLSBHZW5lcmF0b3I6IEljb01vb24uaW8gLS0+IDwhRE9DVFlQRSBzdmcgUFVCTElDICItLy9XM0MvL0RURCBTVkcgMS4xLy9FTiIgImh0dHA6Ly93d3cudzMub3JnL0dyYXBoaWNzL1NWRy8xLjEvRFREL3N2ZzExLmR0ZCI+IDxzdmcgd2lkdGg9IjMyIiBoZWlnaHQ9IjMyIiB2aWV3Qm94PSIwIDAgMzIgMzIiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIGZpbGw9IiNmZmZmZmYiPjxnPjxwYXRoIGQ9Ik0gMTYsMyBDIDEyLjUyOCwzIDkuMjYzLDQuMzUyIDYuODA4LDYuODA4IEMgNC4zNTIsOS4yNjMgMywxMi41MjggMywxNiBDIDMsMTkuNDcyIDQuMzUyLDIyLjczNyA2LjgwOCwyNS4xOTIgQyA5LjI2MywyNy42NDggMTIuNTI4LDI5IDE2LDI5IEMgMTkuNDcyLDI5IDIyLjczNywyNy42NDggMjUuMTkyLDI1LjE5MiBDIDI3LjY0OCwyMi43MzcgMjksMTkuNDcyIDI5LDE2IEMgMjksMTIuNTI4IDI3LjY0OCw5LjI2MyAyNS4xOTIsNi44MDggQyAyMi43MzcsNC4zNTIgMTkuNDcyLDMgMTYsMyBaIE0gMTYsMCBMIDE2LDAgQyAyNC44MzcsMCAzMiw3LjE2MyAzMiwxNiBDIDMyLDI0LjgzNyAyNC44MzcsMzIgMTYsMzIgQyA3LjE2MywzMiAwLDI0LjgzNyAwLDE2IEMgMCw3LjE2MyA3LjE2MywwIDE2LDAgWk0gMTQsMjJMIDE4LDIyTCAxOCwyNkwgMTQsMjZ6TSAxNCw2TCAxOCw2TCAxOCwxOEwgMTQsMTh6Ij48L3BhdGg+PC9nPjwvc3ZnPg==) no-repeat center center;
+  background-size: 30px 100%; }
+
+.effeckt-button[data-effeckt-type~="icon-slide"] {
   overflow: hidden;
   padding: 0; }
-
-.effeckt-button--icon-slide__label {
-  padding: 0.8rem 1rem;
-  display: block;
-  position: relative;
-  transition: transform 500ms; }
-  .effeckt-button--icon-slide__label:before {
+  .effeckt-button[data-effeckt-type~="icon-slide"] .effeckt-button-label {
+    padding: 0.8rem 1rem;
     display: block;
-    position: absolute;
-    width: 100%;
-    height: 100%; }
+    position: relative;
+    transition: transform 500ms; }
+    .effeckt-button[data-effeckt-type~="icon-slide"] .effeckt-button-label:before {
+      content: '';
+      display: block;
+      position: absolute;
+      width: 100%;
+      height: 100%; }
 
-.effeckt-button--icon-slide--from-top .effeckt-button--icon-slide__label:before {
-  top: -100%; }
-
-.effeckt-button--icon-slide--from-bottom .effeckt-button--icon-slide__label:before {
-  bottom: -100%; }
-
-.effeckt-button--icon-slide--from-left .effeckt-button--icon-slide__label:before {
-  left: -100%; }
-
-.effeckt-button--icon-slide--from-right .effeckt-button--icon-slide__label:before {
-  right: -100%; }
-
-.effeckt-button--icon-slide--from-top .effeckt-button--icon-slide__label:before, .effeckt-button--icon-slide--from-bottom .effeckt-button--icon-slide__label:before {
+.effeckt-button[data-effeckt-type~="icon-slide"][data-effeckt-type~="from-top"] .effeckt-button-label:before {
+  top: -100%;
   left: 0;
   right: 0; }
-
-.effeckt-button--icon-slide--from-left .effeckt-button--icon-slide__label:before, .effeckt-button--icon-slide--from-right .effeckt-button--icon-slide__label:before {
+.effeckt-button[data-effeckt-type~="icon-slide"][data-effeckt-type~="from-bottom"] .effeckt-button-label:before {
+  bottom: -100%;
+  left: 0;
+  right: 0; }
+.effeckt-button[data-effeckt-type~="icon-slide"][data-effeckt-type~="from-left"] .effeckt-button-label:before {
+  left: -100%;
+  top: 0;
+  bottom: 0; }
+.effeckt-button[data-effeckt-type~="icon-slide"][data-effeckt-type~="from-right"] .effeckt-button-label:before {
+  right: -100%;
   top: 0;
   bottom: 0; }
 
-.effeckt-button--icon-slide:hover.effeckt-button--icon-slide--from-top .effeckt-button--icon-slide__label {
+.effeckt-button[data-effeckt-type~="icon-slide"]:hover[data-effeckt-type~="from-top"] .effeckt-button-label {
   transform: translateY(100%); }
-.effeckt-button--icon-slide:hover.effeckt-button--icon-slide--from-bottom .effeckt-button--icon-slide__label {
+.effeckt-button[data-effeckt-type~="icon-slide"]:hover[data-effeckt-type~="from-bottom"] .effeckt-button-label {
   transform: translateY(-100%); }
-.effeckt-button--icon-slide:hover.effeckt-button--icon-slide--from-left .effeckt-button--icon-slide__label {
+.effeckt-button[data-effeckt-type~="icon-slide"]:hover[data-effeckt-type~="from-left"] .effeckt-button-label {
   transform: translateX(100%); }
-.effeckt-button--icon-slide:hover.effeckt-button--icon-slide--from-right .effeckt-button--icon-slide__label {
+.effeckt-button[data-effeckt-type~="icon-slide"]:hover[data-effeckt-type~="from-right"] .effeckt-button-label {
   transform: translateX(-100%); }
 
 .effeckt-caption {

--- a/css/modules/buttons.autoprefixed.css
+++ b/css/modules/buttons.autoprefixed.css
@@ -347,24 +347,26 @@
   z-index: 1;
 }
 
-/* The effeckt-button--icon-slide__icon--demo data-URI and class are for demo purposes.
-A user could apply their own class to the button's label to designate
-the icon/image they want sliding in and out -- utilizing the :before
-pseudo-element to place a background image or character from an icon
-font. */
+/*==========================
+ICON SLIDE
 
-.effeckt-button--icon-slide__icon--demo:before {
-  content: '';
+Example markup:
+<button class="effeckt-button" data-effeckt-type="icon-slide from-top">
+  <span class="effeckt-button-label demo-button-icon">Icon from top</span>
+</button>
+==========================*/
+
+.demo-button-icon:before {
   background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPCEtLSBHZW5lcmF0b3I6IEljb01vb24uaW8gLS0+IDwhRE9DVFlQRSBzdmcgUFVCTElDICItLy9XM0MvL0RURCBTVkcgMS4xLy9FTiIgImh0dHA6Ly93d3cudzMub3JnL0dyYXBoaWNzL1NWRy8xLjEvRFREL3N2ZzExLmR0ZCI+IDxzdmcgd2lkdGg9IjMyIiBoZWlnaHQ9IjMyIiB2aWV3Qm94PSIwIDAgMzIgMzIiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIGZpbGw9IiNmZmZmZmYiPjxnPjxwYXRoIGQ9Ik0gMTYsMyBDIDEyLjUyOCwzIDkuMjYzLDQuMzUyIDYuODA4LDYuODA4IEMgNC4zNTIsOS4yNjMgMywxMi41MjggMywxNiBDIDMsMTkuNDcyIDQuMzUyLDIyLjczNyA2LjgwOCwyNS4xOTIgQyA5LjI2MywyNy42NDggMTIuNTI4LDI5IDE2LDI5IEMgMTkuNDcyLDI5IDIyLjczNywyNy42NDggMjUuMTkyLDI1LjE5MiBDIDI3LjY0OCwyMi43MzcgMjksMTkuNDcyIDI5LDE2IEMgMjksMTIuNTI4IDI3LjY0OCw5LjI2MyAyNS4xOTIsNi44MDggQyAyMi43MzcsNC4zNTIgMTkuNDcyLDMgMTYsMyBaIE0gMTYsMCBMIDE2LDAgQyAyNC44MzcsMCAzMiw3LjE2MyAzMiwxNiBDIDMyLDI0LjgzNyAyNC44MzcsMzIgMTYsMzIgQyA3LjE2MywzMiAwLDI0LjgzNyAwLDE2IEMgMCw3LjE2MyA3LjE2MywwIDE2LDAgWk0gMTQsMjJMIDE4LDIyTCAxOCwyNkwgMTQsMjZ6TSAxNCw2TCAxOCw2TCAxOCwxOEwgMTQsMTh6Ij48L3BhdGg+PC9nPjwvc3ZnPg==) no-repeat center center;
-  background-size: 30px 30px;
+  background-size: 30px 100%;
 }
 
-.effeckt-button--icon-slide {
+.effeckt-button[data-effeckt-type~="icon-slide"] {
   overflow: hidden;
   padding: 0;
 }
 
-.effeckt-button--icon-slide__label {
+.effeckt-button[data-effeckt-type~="icon-slide"] .effeckt-button-label {
   padding: 0.8rem 1rem;
   display: block;
   position: relative;
@@ -374,63 +376,60 @@ font. */
   transition: transform 500ms;
 }
 
-.effeckt-button--icon-slide__label:before {
+.effeckt-button[data-effeckt-type~="icon-slide"] .effeckt-button-label:before {
+  content: '';
   display: block;
   position: absolute;
   width: 100%;
   height: 100%;
 }
 
-.effeckt-button--icon-slide--from-top .effeckt-button--icon-slide__label:before {
+.effeckt-button[data-effeckt-type~="icon-slide"][data-effeckt-type~="from-top"] .effeckt-button-label:before {
   top: -100%;
-}
-
-.effeckt-button--icon-slide--from-bottom .effeckt-button--icon-slide__label:before {
-  bottom: -100%;
-}
-
-.effeckt-button--icon-slide--from-left .effeckt-button--icon-slide__label:before {
-  left: -100%;
-}
-
-.effeckt-button--icon-slide--from-right .effeckt-button--icon-slide__label:before {
-  right: -100%;
-}
-
-.effeckt-button--icon-slide--from-top .effeckt-button--icon-slide__label:before,
-.effeckt-button--icon-slide--from-bottom .effeckt-button--icon-slide__label:before {
   left: 0;
   right: 0;
 }
 
-.effeckt-button--icon-slide--from-left .effeckt-button--icon-slide__label:before,
-.effeckt-button--icon-slide--from-right .effeckt-button--icon-slide__label:before {
+.effeckt-button[data-effeckt-type~="icon-slide"][data-effeckt-type~="from-bottom"] .effeckt-button-label:before {
+  bottom: -100%;
+  left: 0;
+  right: 0;
+}
+
+.effeckt-button[data-effeckt-type~="icon-slide"][data-effeckt-type~="from-left"] .effeckt-button-label:before {
+  left: -100%;
   top: 0;
   bottom: 0;
 }
 
-.effeckt-button--icon-slide:hover.effeckt-button--icon-slide--from-top .effeckt-button--icon-slide__label {
+.effeckt-button[data-effeckt-type~="icon-slide"][data-effeckt-type~="from-right"] .effeckt-button-label:before {
+  right: -100%;
+  top: 0;
+  bottom: 0;
+}
+
+.effeckt-button[data-effeckt-type~="icon-slide"]:hover[data-effeckt-type~="from-top"] .effeckt-button-label {
   -webkit-transform: translateY(100%);
   -ms-transform: translateY(100%);
   -o-transform: translateY(100%);
   transform: translateY(100%);
 }
 
-.effeckt-button--icon-slide:hover.effeckt-button--icon-slide--from-bottom .effeckt-button--icon-slide__label {
+.effeckt-button[data-effeckt-type~="icon-slide"]:hover[data-effeckt-type~="from-bottom"] .effeckt-button-label {
   -webkit-transform: translateY(-100%);
   -ms-transform: translateY(-100%);
   -o-transform: translateY(-100%);
   transform: translateY(-100%);
 }
 
-.effeckt-button--icon-slide:hover.effeckt-button--icon-slide--from-left .effeckt-button--icon-slide__label {
+.effeckt-button[data-effeckt-type~="icon-slide"]:hover[data-effeckt-type~="from-left"] .effeckt-button-label {
   -webkit-transform: translateX(100%);
   -ms-transform: translateX(100%);
   -o-transform: translateX(100%);
   transform: translateX(100%);
 }
 
-.effeckt-button--icon-slide:hover.effeckt-button--icon-slide--from-right .effeckt-button--icon-slide__label {
+.effeckt-button[data-effeckt-type~="icon-slide"]:hover[data-effeckt-type~="from-right"] .effeckt-button-label {
   -webkit-transform: translateX(-100%);
   -ms-transform: translateX(-100%);
   -o-transform: translateX(-100%);

--- a/css/modules/buttons.css
+++ b/css/modules/buttons.css
@@ -241,56 +241,55 @@
   position: relative;
   z-index: 1; }
 
-/* The effeckt-button--icon-slide__icon--demo data-URI and class are for demo purposes.
-A user could apply their own class to the button's label to designate
-the icon/image they want sliding in and out -- utilizing the :before
-pseudo-element to place a background image or character from an icon
-font. */
-.effeckt-button--icon-slide__icon--demo:before {
-  content: '';
-  background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPCEtLSBHZW5lcmF0b3I6IEljb01vb24uaW8gLS0+IDwhRE9DVFlQRSBzdmcgUFVCTElDICItLy9XM0MvL0RURCBTVkcgMS4xLy9FTiIgImh0dHA6Ly93d3cudzMub3JnL0dyYXBoaWNzL1NWRy8xLjEvRFREL3N2ZzExLmR0ZCI+IDxzdmcgd2lkdGg9IjMyIiBoZWlnaHQ9IjMyIiB2aWV3Qm94PSIwIDAgMzIgMzIiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIGZpbGw9IiNmZmZmZmYiPjxnPjxwYXRoIGQ9Ik0gMTYsMyBDIDEyLjUyOCwzIDkuMjYzLDQuMzUyIDYuODA4LDYuODA4IEMgNC4zNTIsOS4yNjMgMywxMi41MjggMywxNiBDIDMsMTkuNDcyIDQuMzUyLDIyLjczNyA2LjgwOCwyNS4xOTIgQyA5LjI2MywyNy42NDggMTIuNTI4LDI5IDE2LDI5IEMgMTkuNDcyLDI5IDIyLjczNywyNy42NDggMjUuMTkyLDI1LjE5MiBDIDI3LjY0OCwyMi43MzcgMjksMTkuNDcyIDI5LDE2IEMgMjksMTIuNTI4IDI3LjY0OCw5LjI2MyAyNS4xOTIsNi44MDggQyAyMi43MzcsNC4zNTIgMTkuNDcyLDMgMTYsMyBaIE0gMTYsMCBMIDE2LDAgQyAyNC44MzcsMCAzMiw3LjE2MyAzMiwxNiBDIDMyLDI0LjgzNyAyNC44MzcsMzIgMTYsMzIgQyA3LjE2MywzMiAwLDI0LjgzNyAwLDE2IEMgMCw3LjE2MyA3LjE2MywwIDE2LDAgWk0gMTQsMjJMIDE4LDIyTCAxOCwyNkwgMTQsMjZ6TSAxNCw2TCAxOCw2TCAxOCwxOEwgMTQsMTh6Ij48L3BhdGg+PC9nPjwvc3ZnPg==) no-repeat center center;
-  background-size: 30px 30px; }
+/*==========================
+ICON SLIDE
 
-.effeckt-button--icon-slide {
+Example markup:
+<button class="effeckt-button" data-effeckt-type="icon-slide from-top">
+  <span class="effeckt-button-label demo-button-icon">Icon from top</span>
+</button>
+==========================*/
+.demo-button-icon:before {
+  background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPCEtLSBHZW5lcmF0b3I6IEljb01vb24uaW8gLS0+IDwhRE9DVFlQRSBzdmcgUFVCTElDICItLy9XM0MvL0RURCBTVkcgMS4xLy9FTiIgImh0dHA6Ly93d3cudzMub3JnL0dyYXBoaWNzL1NWRy8xLjEvRFREL3N2ZzExLmR0ZCI+IDxzdmcgd2lkdGg9IjMyIiBoZWlnaHQ9IjMyIiB2aWV3Qm94PSIwIDAgMzIgMzIiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIGZpbGw9IiNmZmZmZmYiPjxnPjxwYXRoIGQ9Ik0gMTYsMyBDIDEyLjUyOCwzIDkuMjYzLDQuMzUyIDYuODA4LDYuODA4IEMgNC4zNTIsOS4yNjMgMywxMi41MjggMywxNiBDIDMsMTkuNDcyIDQuMzUyLDIyLjczNyA2LjgwOCwyNS4xOTIgQyA5LjI2MywyNy42NDggMTIuNTI4LDI5IDE2LDI5IEMgMTkuNDcyLDI5IDIyLjczNywyNy42NDggMjUuMTkyLDI1LjE5MiBDIDI3LjY0OCwyMi43MzcgMjksMTkuNDcyIDI5LDE2IEMgMjksMTIuNTI4IDI3LjY0OCw5LjI2MyAyNS4xOTIsNi44MDggQyAyMi43MzcsNC4zNTIgMTkuNDcyLDMgMTYsMyBaIE0gMTYsMCBMIDE2LDAgQyAyNC44MzcsMCAzMiw3LjE2MyAzMiwxNiBDIDMyLDI0LjgzNyAyNC44MzcsMzIgMTYsMzIgQyA3LjE2MywzMiAwLDI0LjgzNyAwLDE2IEMgMCw3LjE2MyA3LjE2MywwIDE2LDAgWk0gMTQsMjJMIDE4LDIyTCAxOCwyNkwgMTQsMjZ6TSAxNCw2TCAxOCw2TCAxOCwxOEwgMTQsMTh6Ij48L3BhdGg+PC9nPjwvc3ZnPg==) no-repeat center center;
+  background-size: 30px 100%; }
+
+.effeckt-button[data-effeckt-type~="icon-slide"] {
   overflow: hidden;
   padding: 0; }
-
-.effeckt-button--icon-slide__label {
-  padding: 0.8rem 1rem;
-  display: block;
-  position: relative;
-  transition: transform 500ms; }
-  .effeckt-button--icon-slide__label:before {
+  .effeckt-button[data-effeckt-type~="icon-slide"] .effeckt-button-label {
+    padding: 0.8rem 1rem;
     display: block;
-    position: absolute;
-    width: 100%;
-    height: 100%; }
+    position: relative;
+    transition: transform 500ms; }
+    .effeckt-button[data-effeckt-type~="icon-slide"] .effeckt-button-label:before {
+      content: '';
+      display: block;
+      position: absolute;
+      width: 100%;
+      height: 100%; }
 
-.effeckt-button--icon-slide--from-top .effeckt-button--icon-slide__label:before {
-  top: -100%; }
-
-.effeckt-button--icon-slide--from-bottom .effeckt-button--icon-slide__label:before {
-  bottom: -100%; }
-
-.effeckt-button--icon-slide--from-left .effeckt-button--icon-slide__label:before {
-  left: -100%; }
-
-.effeckt-button--icon-slide--from-right .effeckt-button--icon-slide__label:before {
-  right: -100%; }
-
-.effeckt-button--icon-slide--from-top .effeckt-button--icon-slide__label:before, .effeckt-button--icon-slide--from-bottom .effeckt-button--icon-slide__label:before {
+.effeckt-button[data-effeckt-type~="icon-slide"][data-effeckt-type~="from-top"] .effeckt-button-label:before {
+  top: -100%;
   left: 0;
   right: 0; }
-
-.effeckt-button--icon-slide--from-left .effeckt-button--icon-slide__label:before, .effeckt-button--icon-slide--from-right .effeckt-button--icon-slide__label:before {
+.effeckt-button[data-effeckt-type~="icon-slide"][data-effeckt-type~="from-bottom"] .effeckt-button-label:before {
+  bottom: -100%;
+  left: 0;
+  right: 0; }
+.effeckt-button[data-effeckt-type~="icon-slide"][data-effeckt-type~="from-left"] .effeckt-button-label:before {
+  left: -100%;
+  top: 0;
+  bottom: 0; }
+.effeckt-button[data-effeckt-type~="icon-slide"][data-effeckt-type~="from-right"] .effeckt-button-label:before {
+  right: -100%;
   top: 0;
   bottom: 0; }
 
-.effeckt-button--icon-slide:hover.effeckt-button--icon-slide--from-top .effeckt-button--icon-slide__label {
+.effeckt-button[data-effeckt-type~="icon-slide"]:hover[data-effeckt-type~="from-top"] .effeckt-button-label {
   transform: translateY(100%); }
-.effeckt-button--icon-slide:hover.effeckt-button--icon-slide--from-bottom .effeckt-button--icon-slide__label {
+.effeckt-button[data-effeckt-type~="icon-slide"]:hover[data-effeckt-type~="from-bottom"] .effeckt-button-label {
   transform: translateY(-100%); }
-.effeckt-button--icon-slide:hover.effeckt-button--icon-slide--from-left .effeckt-button--icon-slide__label {
+.effeckt-button[data-effeckt-type~="icon-slide"]:hover[data-effeckt-type~="from-left"] .effeckt-button-label {
   transform: translateX(100%); }
-.effeckt-button--icon-slide:hover.effeckt-button--icon-slide--from-right .effeckt-button--icon-slide__label {
+.effeckt-button[data-effeckt-type~="icon-slide"]:hover[data-effeckt-type~="from-right"] .effeckt-button-label {
   transform: translateX(-100%); }

--- a/dist/assets/css/effeckt.autoprefixed.css
+++ b/dist/assets/css/effeckt.autoprefixed.css
@@ -347,24 +347,26 @@
   z-index: 1;
 }
 
-/* The effeckt-button--icon-slide__icon--demo data-URI and class are for demo purposes.
-A user could apply their own class to the button's label to designate
-the icon/image they want sliding in and out -- utilizing the :before
-pseudo-element to place a background image or character from an icon
-font. */
+/*==========================
+ICON SLIDE
 
-.effeckt-button--icon-slide__icon--demo:before {
-  content: '';
+Example markup:
+<button class="effeckt-button" data-effeckt-type="icon-slide from-top">
+  <span class="effeckt-button-label demo-button-icon">Icon from top</span>
+</button>
+==========================*/
+
+.demo-button-icon:before {
   background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPCEtLSBHZW5lcmF0b3I6IEljb01vb24uaW8gLS0+IDwhRE9DVFlQRSBzdmcgUFVCTElDICItLy9XM0MvL0RURCBTVkcgMS4xLy9FTiIgImh0dHA6Ly93d3cudzMub3JnL0dyYXBoaWNzL1NWRy8xLjEvRFREL3N2ZzExLmR0ZCI+IDxzdmcgd2lkdGg9IjMyIiBoZWlnaHQ9IjMyIiB2aWV3Qm94PSIwIDAgMzIgMzIiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIGZpbGw9IiNmZmZmZmYiPjxnPjxwYXRoIGQ9Ik0gMTYsMyBDIDEyLjUyOCwzIDkuMjYzLDQuMzUyIDYuODA4LDYuODA4IEMgNC4zNTIsOS4yNjMgMywxMi41MjggMywxNiBDIDMsMTkuNDcyIDQuMzUyLDIyLjczNyA2LjgwOCwyNS4xOTIgQyA5LjI2MywyNy42NDggMTIuNTI4LDI5IDE2LDI5IEMgMTkuNDcyLDI5IDIyLjczNywyNy42NDggMjUuMTkyLDI1LjE5MiBDIDI3LjY0OCwyMi43MzcgMjksMTkuNDcyIDI5LDE2IEMgMjksMTIuNTI4IDI3LjY0OCw5LjI2MyAyNS4xOTIsNi44MDggQyAyMi43MzcsNC4zNTIgMTkuNDcyLDMgMTYsMyBaIE0gMTYsMCBMIDE2LDAgQyAyNC44MzcsMCAzMiw3LjE2MyAzMiwxNiBDIDMyLDI0LjgzNyAyNC44MzcsMzIgMTYsMzIgQyA3LjE2MywzMiAwLDI0LjgzNyAwLDE2IEMgMCw3LjE2MyA3LjE2MywwIDE2LDAgWk0gMTQsMjJMIDE4LDIyTCAxOCwyNkwgMTQsMjZ6TSAxNCw2TCAxOCw2TCAxOCwxOEwgMTQsMTh6Ij48L3BhdGg+PC9nPjwvc3ZnPg==) no-repeat center center;
-  background-size: 30px 30px;
+  background-size: 30px 100%;
 }
 
-.effeckt-button--icon-slide {
+.effeckt-button[data-effeckt-type~="icon-slide"] {
   overflow: hidden;
   padding: 0;
 }
 
-.effeckt-button--icon-slide__label {
+.effeckt-button[data-effeckt-type~="icon-slide"] .effeckt-button-label {
   padding: 0.8rem 1rem;
   display: block;
   position: relative;
@@ -374,63 +376,60 @@ font. */
   transition: transform 500ms;
 }
 
-.effeckt-button--icon-slide__label:before {
+.effeckt-button[data-effeckt-type~="icon-slide"] .effeckt-button-label:before {
+  content: '';
   display: block;
   position: absolute;
   width: 100%;
   height: 100%;
 }
 
-.effeckt-button--icon-slide--from-top .effeckt-button--icon-slide__label:before {
+.effeckt-button[data-effeckt-type~="icon-slide"][data-effeckt-type~="from-top"] .effeckt-button-label:before {
   top: -100%;
-}
-
-.effeckt-button--icon-slide--from-bottom .effeckt-button--icon-slide__label:before {
-  bottom: -100%;
-}
-
-.effeckt-button--icon-slide--from-left .effeckt-button--icon-slide__label:before {
-  left: -100%;
-}
-
-.effeckt-button--icon-slide--from-right .effeckt-button--icon-slide__label:before {
-  right: -100%;
-}
-
-.effeckt-button--icon-slide--from-top .effeckt-button--icon-slide__label:before,
-.effeckt-button--icon-slide--from-bottom .effeckt-button--icon-slide__label:before {
   left: 0;
   right: 0;
 }
 
-.effeckt-button--icon-slide--from-left .effeckt-button--icon-slide__label:before,
-.effeckt-button--icon-slide--from-right .effeckt-button--icon-slide__label:before {
+.effeckt-button[data-effeckt-type~="icon-slide"][data-effeckt-type~="from-bottom"] .effeckt-button-label:before {
+  bottom: -100%;
+  left: 0;
+  right: 0;
+}
+
+.effeckt-button[data-effeckt-type~="icon-slide"][data-effeckt-type~="from-left"] .effeckt-button-label:before {
+  left: -100%;
   top: 0;
   bottom: 0;
 }
 
-.effeckt-button--icon-slide:hover.effeckt-button--icon-slide--from-top .effeckt-button--icon-slide__label {
+.effeckt-button[data-effeckt-type~="icon-slide"][data-effeckt-type~="from-right"] .effeckt-button-label:before {
+  right: -100%;
+  top: 0;
+  bottom: 0;
+}
+
+.effeckt-button[data-effeckt-type~="icon-slide"]:hover[data-effeckt-type~="from-top"] .effeckt-button-label {
   -webkit-transform: translateY(100%);
   -ms-transform: translateY(100%);
   -o-transform: translateY(100%);
   transform: translateY(100%);
 }
 
-.effeckt-button--icon-slide:hover.effeckt-button--icon-slide--from-bottom .effeckt-button--icon-slide__label {
+.effeckt-button[data-effeckt-type~="icon-slide"]:hover[data-effeckt-type~="from-bottom"] .effeckt-button-label {
   -webkit-transform: translateY(-100%);
   -ms-transform: translateY(-100%);
   -o-transform: translateY(-100%);
   transform: translateY(-100%);
 }
 
-.effeckt-button--icon-slide:hover.effeckt-button--icon-slide--from-left .effeckt-button--icon-slide__label {
+.effeckt-button[data-effeckt-type~="icon-slide"]:hover[data-effeckt-type~="from-left"] .effeckt-button-label {
   -webkit-transform: translateX(100%);
   -ms-transform: translateX(100%);
   -o-transform: translateX(100%);
   transform: translateX(100%);
 }
 
-.effeckt-button--icon-slide:hover.effeckt-button--icon-slide--from-right .effeckt-button--icon-slide__label {
+.effeckt-button[data-effeckt-type~="icon-slide"]:hover[data-effeckt-type~="from-right"] .effeckt-button-label {
   -webkit-transform: translateX(-100%);
   -ms-transform: translateX(-100%);
   -o-transform: translateX(-100%);

--- a/dist/assets/css/effeckt.css
+++ b/dist/assets/css/effeckt.css
@@ -241,58 +241,57 @@
   position: relative;
   z-index: 1; }
 
-/* The effeckt-button--icon-slide__icon--demo data-URI and class are for demo purposes.
-A user could apply their own class to the button's label to designate
-the icon/image they want sliding in and out -- utilizing the :before
-pseudo-element to place a background image or character from an icon
-font. */
-.effeckt-button--icon-slide__icon--demo:before {
-  content: '';
-  background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPCEtLSBHZW5lcmF0b3I6IEljb01vb24uaW8gLS0+IDwhRE9DVFlQRSBzdmcgUFVCTElDICItLy9XM0MvL0RURCBTVkcgMS4xLy9FTiIgImh0dHA6Ly93d3cudzMub3JnL0dyYXBoaWNzL1NWRy8xLjEvRFREL3N2ZzExLmR0ZCI+IDxzdmcgd2lkdGg9IjMyIiBoZWlnaHQ9IjMyIiB2aWV3Qm94PSIwIDAgMzIgMzIiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIGZpbGw9IiNmZmZmZmYiPjxnPjxwYXRoIGQ9Ik0gMTYsMyBDIDEyLjUyOCwzIDkuMjYzLDQuMzUyIDYuODA4LDYuODA4IEMgNC4zNTIsOS4yNjMgMywxMi41MjggMywxNiBDIDMsMTkuNDcyIDQuMzUyLDIyLjczNyA2LjgwOCwyNS4xOTIgQyA5LjI2MywyNy42NDggMTIuNTI4LDI5IDE2LDI5IEMgMTkuNDcyLDI5IDIyLjczNywyNy42NDggMjUuMTkyLDI1LjE5MiBDIDI3LjY0OCwyMi43MzcgMjksMTkuNDcyIDI5LDE2IEMgMjksMTIuNTI4IDI3LjY0OCw5LjI2MyAyNS4xOTIsNi44MDggQyAyMi43MzcsNC4zNTIgMTkuNDcyLDMgMTYsMyBaIE0gMTYsMCBMIDE2LDAgQyAyNC44MzcsMCAzMiw3LjE2MyAzMiwxNiBDIDMyLDI0LjgzNyAyNC44MzcsMzIgMTYsMzIgQyA3LjE2MywzMiAwLDI0LjgzNyAwLDE2IEMgMCw3LjE2MyA3LjE2MywwIDE2LDAgWk0gMTQsMjJMIDE4LDIyTCAxOCwyNkwgMTQsMjZ6TSAxNCw2TCAxOCw2TCAxOCwxOEwgMTQsMTh6Ij48L3BhdGg+PC9nPjwvc3ZnPg==) no-repeat center center;
-  background-size: 30px 30px; }
+/*==========================
+ICON SLIDE
 
-.effeckt-button--icon-slide {
+Example markup:
+<button class="effeckt-button" data-effeckt-type="icon-slide from-top">
+  <span class="effeckt-button-label demo-button-icon">Icon from top</span>
+</button>
+==========================*/
+.demo-button-icon:before {
+  background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPCEtLSBHZW5lcmF0b3I6IEljb01vb24uaW8gLS0+IDwhRE9DVFlQRSBzdmcgUFVCTElDICItLy9XM0MvL0RURCBTVkcgMS4xLy9FTiIgImh0dHA6Ly93d3cudzMub3JnL0dyYXBoaWNzL1NWRy8xLjEvRFREL3N2ZzExLmR0ZCI+IDxzdmcgd2lkdGg9IjMyIiBoZWlnaHQ9IjMyIiB2aWV3Qm94PSIwIDAgMzIgMzIiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIGZpbGw9IiNmZmZmZmYiPjxnPjxwYXRoIGQ9Ik0gMTYsMyBDIDEyLjUyOCwzIDkuMjYzLDQuMzUyIDYuODA4LDYuODA4IEMgNC4zNTIsOS4yNjMgMywxMi41MjggMywxNiBDIDMsMTkuNDcyIDQuMzUyLDIyLjczNyA2LjgwOCwyNS4xOTIgQyA5LjI2MywyNy42NDggMTIuNTI4LDI5IDE2LDI5IEMgMTkuNDcyLDI5IDIyLjczNywyNy42NDggMjUuMTkyLDI1LjE5MiBDIDI3LjY0OCwyMi43MzcgMjksMTkuNDcyIDI5LDE2IEMgMjksMTIuNTI4IDI3LjY0OCw5LjI2MyAyNS4xOTIsNi44MDggQyAyMi43MzcsNC4zNTIgMTkuNDcyLDMgMTYsMyBaIE0gMTYsMCBMIDE2LDAgQyAyNC44MzcsMCAzMiw3LjE2MyAzMiwxNiBDIDMyLDI0LjgzNyAyNC44MzcsMzIgMTYsMzIgQyA3LjE2MywzMiAwLDI0LjgzNyAwLDE2IEMgMCw3LjE2MyA3LjE2MywwIDE2LDAgWk0gMTQsMjJMIDE4LDIyTCAxOCwyNkwgMTQsMjZ6TSAxNCw2TCAxOCw2TCAxOCwxOEwgMTQsMTh6Ij48L3BhdGg+PC9nPjwvc3ZnPg==) no-repeat center center;
+  background-size: 30px 100%; }
+
+.effeckt-button[data-effeckt-type~="icon-slide"] {
   overflow: hidden;
   padding: 0; }
-
-.effeckt-button--icon-slide__label {
-  padding: 0.8rem 1rem;
-  display: block;
-  position: relative;
-  transition: transform 500ms; }
-  .effeckt-button--icon-slide__label:before {
+  .effeckt-button[data-effeckt-type~="icon-slide"] .effeckt-button-label {
+    padding: 0.8rem 1rem;
     display: block;
-    position: absolute;
-    width: 100%;
-    height: 100%; }
+    position: relative;
+    transition: transform 500ms; }
+    .effeckt-button[data-effeckt-type~="icon-slide"] .effeckt-button-label:before {
+      content: '';
+      display: block;
+      position: absolute;
+      width: 100%;
+      height: 100%; }
 
-.effeckt-button--icon-slide--from-top .effeckt-button--icon-slide__label:before {
-  top: -100%; }
-
-.effeckt-button--icon-slide--from-bottom .effeckt-button--icon-slide__label:before {
-  bottom: -100%; }
-
-.effeckt-button--icon-slide--from-left .effeckt-button--icon-slide__label:before {
-  left: -100%; }
-
-.effeckt-button--icon-slide--from-right .effeckt-button--icon-slide__label:before {
-  right: -100%; }
-
-.effeckt-button--icon-slide--from-top .effeckt-button--icon-slide__label:before, .effeckt-button--icon-slide--from-bottom .effeckt-button--icon-slide__label:before {
+.effeckt-button[data-effeckt-type~="icon-slide"][data-effeckt-type~="from-top"] .effeckt-button-label:before {
+  top: -100%;
   left: 0;
   right: 0; }
-
-.effeckt-button--icon-slide--from-left .effeckt-button--icon-slide__label:before, .effeckt-button--icon-slide--from-right .effeckt-button--icon-slide__label:before {
+.effeckt-button[data-effeckt-type~="icon-slide"][data-effeckt-type~="from-bottom"] .effeckt-button-label:before {
+  bottom: -100%;
+  left: 0;
+  right: 0; }
+.effeckt-button[data-effeckt-type~="icon-slide"][data-effeckt-type~="from-left"] .effeckt-button-label:before {
+  left: -100%;
+  top: 0;
+  bottom: 0; }
+.effeckt-button[data-effeckt-type~="icon-slide"][data-effeckt-type~="from-right"] .effeckt-button-label:before {
+  right: -100%;
   top: 0;
   bottom: 0; }
 
-.effeckt-button--icon-slide:hover.effeckt-button--icon-slide--from-top .effeckt-button--icon-slide__label {
+.effeckt-button[data-effeckt-type~="icon-slide"]:hover[data-effeckt-type~="from-top"] .effeckt-button-label {
   transform: translateY(100%); }
-.effeckt-button--icon-slide:hover.effeckt-button--icon-slide--from-bottom .effeckt-button--icon-slide__label {
+.effeckt-button[data-effeckt-type~="icon-slide"]:hover[data-effeckt-type~="from-bottom"] .effeckt-button-label {
   transform: translateY(-100%); }
-.effeckt-button--icon-slide:hover.effeckt-button--icon-slide--from-left .effeckt-button--icon-slide__label {
+.effeckt-button[data-effeckt-type~="icon-slide"]:hover[data-effeckt-type~="from-left"] .effeckt-button-label {
   transform: translateX(100%); }
-.effeckt-button--icon-slide:hover.effeckt-button--icon-slide--from-right .effeckt-button--icon-slide__label {
+.effeckt-button[data-effeckt-type~="icon-slide"]:hover[data-effeckt-type~="from-right"] .effeckt-button-label {
   transform: translateX(-100%); }
 
 .effeckt-caption {

--- a/dist/assets/css/modules/buttons.autoprefixed.css
+++ b/dist/assets/css/modules/buttons.autoprefixed.css
@@ -347,24 +347,26 @@
   z-index: 1;
 }
 
-/* The effeckt-button--icon-slide__icon--demo data-URI and class are for demo purposes.
-A user could apply their own class to the button's label to designate
-the icon/image they want sliding in and out -- utilizing the :before
-pseudo-element to place a background image or character from an icon
-font. */
+/*==========================
+ICON SLIDE
 
-.effeckt-button--icon-slide__icon--demo:before {
-  content: '';
+Example markup:
+<button class="effeckt-button" data-effeckt-type="icon-slide from-top">
+  <span class="effeckt-button-label demo-button-icon">Icon from top</span>
+</button>
+==========================*/
+
+.demo-button-icon:before {
   background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPCEtLSBHZW5lcmF0b3I6IEljb01vb24uaW8gLS0+IDwhRE9DVFlQRSBzdmcgUFVCTElDICItLy9XM0MvL0RURCBTVkcgMS4xLy9FTiIgImh0dHA6Ly93d3cudzMub3JnL0dyYXBoaWNzL1NWRy8xLjEvRFREL3N2ZzExLmR0ZCI+IDxzdmcgd2lkdGg9IjMyIiBoZWlnaHQ9IjMyIiB2aWV3Qm94PSIwIDAgMzIgMzIiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIGZpbGw9IiNmZmZmZmYiPjxnPjxwYXRoIGQ9Ik0gMTYsMyBDIDEyLjUyOCwzIDkuMjYzLDQuMzUyIDYuODA4LDYuODA4IEMgNC4zNTIsOS4yNjMgMywxMi41MjggMywxNiBDIDMsMTkuNDcyIDQuMzUyLDIyLjczNyA2LjgwOCwyNS4xOTIgQyA5LjI2MywyNy42NDggMTIuNTI4LDI5IDE2LDI5IEMgMTkuNDcyLDI5IDIyLjczNywyNy42NDggMjUuMTkyLDI1LjE5MiBDIDI3LjY0OCwyMi43MzcgMjksMTkuNDcyIDI5LDE2IEMgMjksMTIuNTI4IDI3LjY0OCw5LjI2MyAyNS4xOTIsNi44MDggQyAyMi43MzcsNC4zNTIgMTkuNDcyLDMgMTYsMyBaIE0gMTYsMCBMIDE2LDAgQyAyNC44MzcsMCAzMiw3LjE2MyAzMiwxNiBDIDMyLDI0LjgzNyAyNC44MzcsMzIgMTYsMzIgQyA3LjE2MywzMiAwLDI0LjgzNyAwLDE2IEMgMCw3LjE2MyA3LjE2MywwIDE2LDAgWk0gMTQsMjJMIDE4LDIyTCAxOCwyNkwgMTQsMjZ6TSAxNCw2TCAxOCw2TCAxOCwxOEwgMTQsMTh6Ij48L3BhdGg+PC9nPjwvc3ZnPg==) no-repeat center center;
-  background-size: 30px 30px;
+  background-size: 30px 100%;
 }
 
-.effeckt-button--icon-slide {
+.effeckt-button[data-effeckt-type~="icon-slide"] {
   overflow: hidden;
   padding: 0;
 }
 
-.effeckt-button--icon-slide__label {
+.effeckt-button[data-effeckt-type~="icon-slide"] .effeckt-button-label {
   padding: 0.8rem 1rem;
   display: block;
   position: relative;
@@ -374,63 +376,60 @@ font. */
   transition: transform 500ms;
 }
 
-.effeckt-button--icon-slide__label:before {
+.effeckt-button[data-effeckt-type~="icon-slide"] .effeckt-button-label:before {
+  content: '';
   display: block;
   position: absolute;
   width: 100%;
   height: 100%;
 }
 
-.effeckt-button--icon-slide--from-top .effeckt-button--icon-slide__label:before {
+.effeckt-button[data-effeckt-type~="icon-slide"][data-effeckt-type~="from-top"] .effeckt-button-label:before {
   top: -100%;
-}
-
-.effeckt-button--icon-slide--from-bottom .effeckt-button--icon-slide__label:before {
-  bottom: -100%;
-}
-
-.effeckt-button--icon-slide--from-left .effeckt-button--icon-slide__label:before {
-  left: -100%;
-}
-
-.effeckt-button--icon-slide--from-right .effeckt-button--icon-slide__label:before {
-  right: -100%;
-}
-
-.effeckt-button--icon-slide--from-top .effeckt-button--icon-slide__label:before,
-.effeckt-button--icon-slide--from-bottom .effeckt-button--icon-slide__label:before {
   left: 0;
   right: 0;
 }
 
-.effeckt-button--icon-slide--from-left .effeckt-button--icon-slide__label:before,
-.effeckt-button--icon-slide--from-right .effeckt-button--icon-slide__label:before {
+.effeckt-button[data-effeckt-type~="icon-slide"][data-effeckt-type~="from-bottom"] .effeckt-button-label:before {
+  bottom: -100%;
+  left: 0;
+  right: 0;
+}
+
+.effeckt-button[data-effeckt-type~="icon-slide"][data-effeckt-type~="from-left"] .effeckt-button-label:before {
+  left: -100%;
   top: 0;
   bottom: 0;
 }
 
-.effeckt-button--icon-slide:hover.effeckt-button--icon-slide--from-top .effeckt-button--icon-slide__label {
+.effeckt-button[data-effeckt-type~="icon-slide"][data-effeckt-type~="from-right"] .effeckt-button-label:before {
+  right: -100%;
+  top: 0;
+  bottom: 0;
+}
+
+.effeckt-button[data-effeckt-type~="icon-slide"]:hover[data-effeckt-type~="from-top"] .effeckt-button-label {
   -webkit-transform: translateY(100%);
   -ms-transform: translateY(100%);
   -o-transform: translateY(100%);
   transform: translateY(100%);
 }
 
-.effeckt-button--icon-slide:hover.effeckt-button--icon-slide--from-bottom .effeckt-button--icon-slide__label {
+.effeckt-button[data-effeckt-type~="icon-slide"]:hover[data-effeckt-type~="from-bottom"] .effeckt-button-label {
   -webkit-transform: translateY(-100%);
   -ms-transform: translateY(-100%);
   -o-transform: translateY(-100%);
   transform: translateY(-100%);
 }
 
-.effeckt-button--icon-slide:hover.effeckt-button--icon-slide--from-left .effeckt-button--icon-slide__label {
+.effeckt-button[data-effeckt-type~="icon-slide"]:hover[data-effeckt-type~="from-left"] .effeckt-button-label {
   -webkit-transform: translateX(100%);
   -ms-transform: translateX(100%);
   -o-transform: translateX(100%);
   transform: translateX(100%);
 }
 
-.effeckt-button--icon-slide:hover.effeckt-button--icon-slide--from-right .effeckt-button--icon-slide__label {
+.effeckt-button[data-effeckt-type~="icon-slide"]:hover[data-effeckt-type~="from-right"] .effeckt-button-label {
   -webkit-transform: translateX(-100%);
   -ms-transform: translateX(-100%);
   -o-transform: translateX(-100%);

--- a/dist/assets/css/modules/buttons.css
+++ b/dist/assets/css/modules/buttons.css
@@ -241,56 +241,55 @@
   position: relative;
   z-index: 1; }
 
-/* The effeckt-button--icon-slide__icon--demo data-URI and class are for demo purposes.
-A user could apply their own class to the button's label to designate
-the icon/image they want sliding in and out -- utilizing the :before
-pseudo-element to place a background image or character from an icon
-font. */
-.effeckt-button--icon-slide__icon--demo:before {
-  content: '';
-  background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPCEtLSBHZW5lcmF0b3I6IEljb01vb24uaW8gLS0+IDwhRE9DVFlQRSBzdmcgUFVCTElDICItLy9XM0MvL0RURCBTVkcgMS4xLy9FTiIgImh0dHA6Ly93d3cudzMub3JnL0dyYXBoaWNzL1NWRy8xLjEvRFREL3N2ZzExLmR0ZCI+IDxzdmcgd2lkdGg9IjMyIiBoZWlnaHQ9IjMyIiB2aWV3Qm94PSIwIDAgMzIgMzIiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIGZpbGw9IiNmZmZmZmYiPjxnPjxwYXRoIGQ9Ik0gMTYsMyBDIDEyLjUyOCwzIDkuMjYzLDQuMzUyIDYuODA4LDYuODA4IEMgNC4zNTIsOS4yNjMgMywxMi41MjggMywxNiBDIDMsMTkuNDcyIDQuMzUyLDIyLjczNyA2LjgwOCwyNS4xOTIgQyA5LjI2MywyNy42NDggMTIuNTI4LDI5IDE2LDI5IEMgMTkuNDcyLDI5IDIyLjczNywyNy42NDggMjUuMTkyLDI1LjE5MiBDIDI3LjY0OCwyMi43MzcgMjksMTkuNDcyIDI5LDE2IEMgMjksMTIuNTI4IDI3LjY0OCw5LjI2MyAyNS4xOTIsNi44MDggQyAyMi43MzcsNC4zNTIgMTkuNDcyLDMgMTYsMyBaIE0gMTYsMCBMIDE2LDAgQyAyNC44MzcsMCAzMiw3LjE2MyAzMiwxNiBDIDMyLDI0LjgzNyAyNC44MzcsMzIgMTYsMzIgQyA3LjE2MywzMiAwLDI0LjgzNyAwLDE2IEMgMCw3LjE2MyA3LjE2MywwIDE2LDAgWk0gMTQsMjJMIDE4LDIyTCAxOCwyNkwgMTQsMjZ6TSAxNCw2TCAxOCw2TCAxOCwxOEwgMTQsMTh6Ij48L3BhdGg+PC9nPjwvc3ZnPg==) no-repeat center center;
-  background-size: 30px 30px; }
+/*==========================
+ICON SLIDE
 
-.effeckt-button--icon-slide {
+Example markup:
+<button class="effeckt-button" data-effeckt-type="icon-slide from-top">
+  <span class="effeckt-button-label demo-button-icon">Icon from top</span>
+</button>
+==========================*/
+.demo-button-icon:before {
+  background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPCEtLSBHZW5lcmF0b3I6IEljb01vb24uaW8gLS0+IDwhRE9DVFlQRSBzdmcgUFVCTElDICItLy9XM0MvL0RURCBTVkcgMS4xLy9FTiIgImh0dHA6Ly93d3cudzMub3JnL0dyYXBoaWNzL1NWRy8xLjEvRFREL3N2ZzExLmR0ZCI+IDxzdmcgd2lkdGg9IjMyIiBoZWlnaHQ9IjMyIiB2aWV3Qm94PSIwIDAgMzIgMzIiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIGZpbGw9IiNmZmZmZmYiPjxnPjxwYXRoIGQ9Ik0gMTYsMyBDIDEyLjUyOCwzIDkuMjYzLDQuMzUyIDYuODA4LDYuODA4IEMgNC4zNTIsOS4yNjMgMywxMi41MjggMywxNiBDIDMsMTkuNDcyIDQuMzUyLDIyLjczNyA2LjgwOCwyNS4xOTIgQyA5LjI2MywyNy42NDggMTIuNTI4LDI5IDE2LDI5IEMgMTkuNDcyLDI5IDIyLjczNywyNy42NDggMjUuMTkyLDI1LjE5MiBDIDI3LjY0OCwyMi43MzcgMjksMTkuNDcyIDI5LDE2IEMgMjksMTIuNTI4IDI3LjY0OCw5LjI2MyAyNS4xOTIsNi44MDggQyAyMi43MzcsNC4zNTIgMTkuNDcyLDMgMTYsMyBaIE0gMTYsMCBMIDE2LDAgQyAyNC44MzcsMCAzMiw3LjE2MyAzMiwxNiBDIDMyLDI0LjgzNyAyNC44MzcsMzIgMTYsMzIgQyA3LjE2MywzMiAwLDI0LjgzNyAwLDE2IEMgMCw3LjE2MyA3LjE2MywwIDE2LDAgWk0gMTQsMjJMIDE4LDIyTCAxOCwyNkwgMTQsMjZ6TSAxNCw2TCAxOCw2TCAxOCwxOEwgMTQsMTh6Ij48L3BhdGg+PC9nPjwvc3ZnPg==) no-repeat center center;
+  background-size: 30px 100%; }
+
+.effeckt-button[data-effeckt-type~="icon-slide"] {
   overflow: hidden;
   padding: 0; }
-
-.effeckt-button--icon-slide__label {
-  padding: 0.8rem 1rem;
-  display: block;
-  position: relative;
-  transition: transform 500ms; }
-  .effeckt-button--icon-slide__label:before {
+  .effeckt-button[data-effeckt-type~="icon-slide"] .effeckt-button-label {
+    padding: 0.8rem 1rem;
     display: block;
-    position: absolute;
-    width: 100%;
-    height: 100%; }
+    position: relative;
+    transition: transform 500ms; }
+    .effeckt-button[data-effeckt-type~="icon-slide"] .effeckt-button-label:before {
+      content: '';
+      display: block;
+      position: absolute;
+      width: 100%;
+      height: 100%; }
 
-.effeckt-button--icon-slide--from-top .effeckt-button--icon-slide__label:before {
-  top: -100%; }
-
-.effeckt-button--icon-slide--from-bottom .effeckt-button--icon-slide__label:before {
-  bottom: -100%; }
-
-.effeckt-button--icon-slide--from-left .effeckt-button--icon-slide__label:before {
-  left: -100%; }
-
-.effeckt-button--icon-slide--from-right .effeckt-button--icon-slide__label:before {
-  right: -100%; }
-
-.effeckt-button--icon-slide--from-top .effeckt-button--icon-slide__label:before, .effeckt-button--icon-slide--from-bottom .effeckt-button--icon-slide__label:before {
+.effeckt-button[data-effeckt-type~="icon-slide"][data-effeckt-type~="from-top"] .effeckt-button-label:before {
+  top: -100%;
   left: 0;
   right: 0; }
-
-.effeckt-button--icon-slide--from-left .effeckt-button--icon-slide__label:before, .effeckt-button--icon-slide--from-right .effeckt-button--icon-slide__label:before {
+.effeckt-button[data-effeckt-type~="icon-slide"][data-effeckt-type~="from-bottom"] .effeckt-button-label:before {
+  bottom: -100%;
+  left: 0;
+  right: 0; }
+.effeckt-button[data-effeckt-type~="icon-slide"][data-effeckt-type~="from-left"] .effeckt-button-label:before {
+  left: -100%;
+  top: 0;
+  bottom: 0; }
+.effeckt-button[data-effeckt-type~="icon-slide"][data-effeckt-type~="from-right"] .effeckt-button-label:before {
+  right: -100%;
   top: 0;
   bottom: 0; }
 
-.effeckt-button--icon-slide:hover.effeckt-button--icon-slide--from-top .effeckt-button--icon-slide__label {
+.effeckt-button[data-effeckt-type~="icon-slide"]:hover[data-effeckt-type~="from-top"] .effeckt-button-label {
   transform: translateY(100%); }
-.effeckt-button--icon-slide:hover.effeckt-button--icon-slide--from-bottom .effeckt-button--icon-slide__label {
+.effeckt-button[data-effeckt-type~="icon-slide"]:hover[data-effeckt-type~="from-bottom"] .effeckt-button-label {
   transform: translateY(-100%); }
-.effeckt-button--icon-slide:hover.effeckt-button--icon-slide--from-left .effeckt-button--icon-slide__label {
+.effeckt-button[data-effeckt-type~="icon-slide"]:hover[data-effeckt-type~="from-left"] .effeckt-button-label {
   transform: translateX(100%); }
-.effeckt-button--icon-slide:hover.effeckt-button--icon-slide--from-right .effeckt-button--icon-slide__label {
+.effeckt-button[data-effeckt-type~="icon-slide"]:hover[data-effeckt-type~="from-right"] .effeckt-button-label {
   transform: translateX(-100%); }

--- a/dist/buttons.html
+++ b/dist/buttons.html
@@ -169,26 +169,26 @@
   </div>
 
   <div class="button-demo-wrap">
-    <button class="effeckt-button effeckt-button--icon-slide effeckt-button--icon-slide--from-top">
-      <span class="effeckt-button--icon-slide__label effeckt-button--icon-slide__icon--demo">Icon from top</span>
+    <button class="effeckt-button" data-effeckt-type="icon-slide from-top">
+      <span class="effeckt-button-label demo-button-icon">Icon from top</span>
     </button>
   </div>
 
   <div class="button-demo-wrap">
-    <button class="effeckt-button effeckt-button--icon-slide effeckt-button--icon-slide--from-bottom">
-      <span class="effeckt-button--icon-slide__label effeckt-button--icon-slide__icon--demo">Icon from bottom</span>
+    <button class="effeckt-button" data-effeckt-type="icon-slide from-bottom">
+      <span class="effeckt-button-label demo-button-icon">Icon from bottom</span>
     </button>
   </div>
 
   <div class="button-demo-wrap">
-    <button class="effeckt-button effeckt-button--icon-slide effeckt-button--icon-slide--from-left">
-      <span class="effeckt-button--icon-slide__label effeckt-button--icon-slide__icon--demo">Icon from left</span>
+    <button class="effeckt-button" data-effeckt-type="icon-slide from-left">
+      <span class="effeckt-button-label demo-button-icon">Icon from left</span>
     </button>
   </div>
 
   <div class="button-demo-wrap">
-    <button class="effeckt-button effeckt-button--icon-slide effeckt-button--icon-slide--from-right">
-      <span class="effeckt-button--icon-slide__label effeckt-button--icon-slide__icon--demo">Icon from right</span>
+    <button class="effeckt-button" data-effeckt-type="icon-slide from-right">
+      <span class="effeckt-button-label demo-button-icon">Icon from right</span>
     </button>
   </div>
 

--- a/dist/index.html
+++ b/dist/index.html
@@ -216,26 +216,26 @@
   </div>
 
   <div class="button-demo-wrap">
-    <button class="effeckt-button effeckt-button--icon-slide effeckt-button--icon-slide--from-top">
-      <span class="effeckt-button--icon-slide__label effeckt-button--icon-slide__icon--demo">Icon from top</span>
+    <button class="effeckt-button" data-effeckt-type="icon-slide from-top">
+      <span class="effeckt-button-label demo-button-icon">Icon from top</span>
     </button>
   </div>
 
   <div class="button-demo-wrap">
-    <button class="effeckt-button effeckt-button--icon-slide effeckt-button--icon-slide--from-bottom">
-      <span class="effeckt-button--icon-slide__label effeckt-button--icon-slide__icon--demo">Icon from bottom</span>
+    <button class="effeckt-button" data-effeckt-type="icon-slide from-bottom">
+      <span class="effeckt-button-label demo-button-icon">Icon from bottom</span>
     </button>
   </div>
 
   <div class="button-demo-wrap">
-    <button class="effeckt-button effeckt-button--icon-slide effeckt-button--icon-slide--from-left">
-      <span class="effeckt-button--icon-slide__label effeckt-button--icon-slide__icon--demo">Icon from left</span>
+    <button class="effeckt-button" data-effeckt-type="icon-slide from-left">
+      <span class="effeckt-button-label demo-button-icon">Icon from left</span>
     </button>
   </div>
 
   <div class="button-demo-wrap">
-    <button class="effeckt-button effeckt-button--icon-slide effeckt-button--icon-slide--from-right">
-      <span class="effeckt-button--icon-slide__label effeckt-button--icon-slide__icon--demo">Icon from right</span>
+    <button class="effeckt-button" data-effeckt-type="icon-slide from-right">
+      <span class="effeckt-button-label demo-button-icon">Icon from right</span>
     </button>
   </div>
 

--- a/scss/modules/buttons.scss
+++ b/scss/modules/buttons.scss
@@ -333,82 +333,90 @@
 }
 
 
-// Icon slide
+/*==========================
+ICON SLIDE
 
-/* The effeckt-button--icon-slide__icon--demo data-URI and class are for demo purposes.
-A user could apply their own class to the button's label to designate
-the icon/image they want sliding in and out -- utilizing the :before
-pseudo-element to place a background image or character from an icon
-font. */
-$effeckt-button--icon-slide__icon--demo: "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPCEtLSBHZW5lcmF0b3I6IEljb01vb24uaW8gLS0+IDwhRE9DVFlQRSBzdmcgUFVCTElDICItLy9XM0MvL0RURCBTVkcgMS4xLy9FTiIgImh0dHA6Ly93d3cudzMub3JnL0dyYXBoaWNzL1NWRy8xLjEvRFREL3N2ZzExLmR0ZCI+IDxzdmcgd2lkdGg9IjMyIiBoZWlnaHQ9IjMyIiB2aWV3Qm94PSIwIDAgMzIgMzIiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIGZpbGw9IiNmZmZmZmYiPjxnPjxwYXRoIGQ9Ik0gMTYsMyBDIDEyLjUyOCwzIDkuMjYzLDQuMzUyIDYuODA4LDYuODA4IEMgNC4zNTIsOS4yNjMgMywxMi41MjggMywxNiBDIDMsMTkuNDcyIDQuMzUyLDIyLjczNyA2LjgwOCwyNS4xOTIgQyA5LjI2MywyNy42NDggMTIuNTI4LDI5IDE2LDI5IEMgMTkuNDcyLDI5IDIyLjczNywyNy42NDggMjUuMTkyLDI1LjE5MiBDIDI3LjY0OCwyMi43MzcgMjksMTkuNDcyIDI5LDE2IEMgMjksMTIuNTI4IDI3LjY0OCw5LjI2MyAyNS4xOTIsNi44MDggQyAyMi43MzcsNC4zNTIgMTkuNDcyLDMgMTYsMyBaIE0gMTYsMCBMIDE2LDAgQyAyNC44MzcsMCAzMiw3LjE2MyAzMiwxNiBDIDMyLDI0LjgzNyAyNC44MzcsMzIgMTYsMzIgQyA3LjE2MywzMiAwLDI0LjgzNyAwLDE2IEMgMCw3LjE2MyA3LjE2MywwIDE2LDAgWk0gMTQsMjJMIDE4LDIyTCAxOCwyNkwgMTQsMjZ6TSAxNCw2TCAxOCw2TCAxOCwxOEwgMTQsMTh6Ij48L3BhdGg+PC9nPjwvc3ZnPg==";
-.effeckt-button--icon-slide__icon--demo:before {
-  content: '';
-  background: url(#{$effeckt-button--icon-slide__icon--demo}) no-repeat center center;
-  background-size: 30px 30px;
+Example markup:
+<button class="effeckt-button" data-effeckt-type="icon-slide from-top">
+  <span class="effeckt-button-label demo-button-icon">Icon from top</span>
+</button>
+==========================*/
+
+/// The "effeckt-button-icon" data-URI and "demo-button-icon" class
+// are for demo purposes. A user could apply their own class to the
+// button's label to designate the icon/image they want sliding in
+// and out -- utilizing the :before pseudo-element to place a
+// background image or character from an icon font.
+$effeckt-button-icon: "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPCEtLSBHZW5lcmF0b3I6IEljb01vb24uaW8gLS0+IDwhRE9DVFlQRSBzdmcgUFVCTElDICItLy9XM0MvL0RURCBTVkcgMS4xLy9FTiIgImh0dHA6Ly93d3cudzMub3JnL0dyYXBoaWNzL1NWRy8xLjEvRFREL3N2ZzExLmR0ZCI+IDxzdmcgd2lkdGg9IjMyIiBoZWlnaHQ9IjMyIiB2aWV3Qm94PSIwIDAgMzIgMzIiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIGZpbGw9IiNmZmZmZmYiPjxnPjxwYXRoIGQ9Ik0gMTYsMyBDIDEyLjUyOCwzIDkuMjYzLDQuMzUyIDYuODA4LDYuODA4IEMgNC4zNTIsOS4yNjMgMywxMi41MjggMywxNiBDIDMsMTkuNDcyIDQuMzUyLDIyLjczNyA2LjgwOCwyNS4xOTIgQyA5LjI2MywyNy42NDggMTIuNTI4LDI5IDE2LDI5IEMgMTkuNDcyLDI5IDIyLjczNywyNy42NDggMjUuMTkyLDI1LjE5MiBDIDI3LjY0OCwyMi43MzcgMjksMTkuNDcyIDI5LDE2IEMgMjksMTIuNTI4IDI3LjY0OCw5LjI2MyAyNS4xOTIsNi44MDggQyAyMi43MzcsNC4zNTIgMTkuNDcyLDMgMTYsMyBaIE0gMTYsMCBMIDE2LDAgQyAyNC44MzcsMCAzMiw3LjE2MyAzMiwxNiBDIDMyLDI0LjgzNyAyNC44MzcsMzIgMTYsMzIgQyA3LjE2MywzMiAwLDI0LjgzNyAwLDE2IEMgMCw3LjE2MyA3LjE2MywwIDE2LDAgWk0gMTQsMjJMIDE4LDIyTCAxOCwyNkwgMTQsMjZ6TSAxNCw2TCAxOCw2TCAxOCwxOEwgMTQsMTh6Ij48L3BhdGg+PC9nPjwvc3ZnPg==";
+.demo-button-icon:before {
+  background: url(#{$effeckt-button-icon}) no-repeat center center;
+  background-size: 30px 100%;
 }
 
-.effeckt-button--icon-slide {
+// General styles
+.effeckt-button[data-effeckt-type~="icon-slide"] {
   overflow: hidden;
   // Any padding has to be applied to the inner element, instead of the container.
-  // So, override the default styling of .effeckt-button.
+  // So, override the default styling of .effeckt-button from demo.scss.
   padding: 0;
-}
-
-.effeckt-button--icon-slide__label {
-  padding: 0.8rem 1rem; // Then replace it here.
-  display: block;
-  position: relative;
-  transition: transform $effeckt-buttons-transition-duration;
-  &:before {
+  .effeckt-button-label {
+    padding: 0.8rem 1rem; // And re-apply it here.
     display: block;
-    position: absolute;
-    width: 100%;
-    height: 100%;
+    position: relative;
+    transition: transform $effeckt-buttons-transition-duration;
+    &:before {
+      content: '';
+      display: block;
+      position: absolute;
+      width: 100%;
+      height: 100%;
+    }
   }
 }
 
-.effeckt-button--icon-slide--from-top .effeckt-button--icon-slide__label:before {
-  top: -100%;
-}
-.effeckt-button--icon-slide--from-bottom .effeckt-button--icon-slide__label:before {
-  bottom: -100%;
-}
-.effeckt-button--icon-slide--from-left .effeckt-button--icon-slide__label:before {
-  left: -100%;
-}
-.effeckt-button--icon-slide--from-right .effeckt-button--icon-slide__label:before {
-  right: -100%;
-}
-  // Compensating for the label's padding.
-.effeckt-button--icon-slide--from-top,
-.effeckt-button--icon-slide--from-bottom {
-  .effeckt-button--icon-slide__label:before {
+// Direction-specific styles
+.effeckt-button[data-effeckt-type~="icon-slide"] {
+  // From top
+  &[data-effeckt-type~="from-top"] .effeckt-button-label:before {
+    top: -100%;
     left: 0;
     right: 0;
   }
-}
-.effeckt-button--icon-slide--from-left,
-.effeckt-button--icon-slide--from-right {
-  .effeckt-button--icon-slide__label:before {
+  // From bottom
+  &[data-effeckt-type~="from-bottom"] .effeckt-button-label:before {
+    bottom: -100%;
+    left: 0;
+    right: 0;
+  }
+  // From left
+  &[data-effeckt-type~="from-left"] .effeckt-button-label:before {
+    left: -100%;
+    top: 0;
+    bottom: 0;
+  }
+  // From left
+  &[data-effeckt-type~="from-right"] .effeckt-button-label:before {
+    right: -100%;
     top: 0;
     bottom: 0;
   }
 }
 
-.effeckt-button--icon-slide:hover {
-  // This hover effect could be applied to a class, instead,
-  // to make it click based. Hover is for the demo.
-  &.effeckt-button--icon-slide--from-top .effeckt-button--icon-slide__label {
+// Active state -- could be applied to a class or data-attribute, instead,
+// to make it JS triggered. Hover is easiest for the demo.
+.effeckt-button[data-effeckt-type~="icon-slide"]:hover {
+  &[data-effeckt-type~="from-top"] .effeckt-button-label {
     transform: translateY(100%);
   }
-  &.effeckt-button--icon-slide--from-bottom .effeckt-button--icon-slide__label {
+  &[data-effeckt-type~="from-bottom"] .effeckt-button-label {
     transform: translateY(-100%);
   }
-  &.effeckt-button--icon-slide--from-left .effeckt-button--icon-slide__label {
+  &[data-effeckt-type~="from-left"] .effeckt-button-label {
     transform: translateX(100%);
   }
-  &.effeckt-button--icon-slide--from-right .effeckt-button--icon-slide__label {
+  &[data-effeckt-type~="from-right"] .effeckt-button-label {
     transform: translateX(-100%);
   }
 }
+
 

--- a/src/templates/pages/buttons.hbs
+++ b/src/templates/pages/buttons.hbs
@@ -74,26 +74,26 @@
   </div>
 
   <div class="button-demo-wrap">
-    <button class="effeckt-button effeckt-button--icon-slide effeckt-button--icon-slide--from-top">
-      <span class="effeckt-button--icon-slide__label effeckt-button--icon-slide__icon--demo">Icon from top</span>
+    <button class="effeckt-button" data-effeckt-type="icon-slide from-top">
+      <span class="effeckt-button-label demo-button-icon">Icon from top</span>
     </button>
   </div>
 
   <div class="button-demo-wrap">
-    <button class="effeckt-button effeckt-button--icon-slide effeckt-button--icon-slide--from-bottom">
-      <span class="effeckt-button--icon-slide__label effeckt-button--icon-slide__icon--demo">Icon from bottom</span>
+    <button class="effeckt-button" data-effeckt-type="icon-slide from-bottom">
+      <span class="effeckt-button-label demo-button-icon">Icon from bottom</span>
     </button>
   </div>
 
   <div class="button-demo-wrap">
-    <button class="effeckt-button effeckt-button--icon-slide effeckt-button--icon-slide--from-left">
-      <span class="effeckt-button--icon-slide__label effeckt-button--icon-slide__icon--demo">Icon from left</span>
+    <button class="effeckt-button" data-effeckt-type="icon-slide from-left">
+      <span class="effeckt-button-label demo-button-icon">Icon from left</span>
     </button>
   </div>
 
   <div class="button-demo-wrap">
-    <button class="effeckt-button effeckt-button--icon-slide effeckt-button--icon-slide--from-right">
-      <span class="effeckt-button--icon-slide__label effeckt-button--icon-slide__icon--demo">Icon from right</span>
+    <button class="effeckt-button" data-effeckt-type="icon-slide from-right">
+      <span class="effeckt-button-label demo-button-icon">Icon from right</span>
     </button>
   </div>
 


### PR DESCRIPTION
Following up on https://github.com/h5bp/Effeckt.css/issues/147 :

I've tried to apply the proposed class/data-attribute naming conventions to the sliding icon buttons. So the button markup looks like this:

``` html
<button class="effeckt-button" data-effeckt-type="icon-slide from-top">
  <span class="effeckt-button-label user-designated-icon">Icon from top</span>
</button>
```

For demo purposes, I have the effect run on hover -- but the SCSS could be easily altered so that the effect runs when JS applies `data-effeckt-state="active"`.
