### PR TITLE
off screen nav: left squeeze now pushes page to the right

### DIFF
--- a/css/effeckt.autoprefixed.css
+++ b/css/effeckt.autoprefixed.css
@@ -3332,6 +3332,7 @@ Example markup:
 }
 
 .effeckt-off-screen-nav-left-squeeze ~ [data-effeckt-page] {
+  float: right;
   -webkit-transition: width 500ms;
   -o-transition: width 500ms;
   transition: width 500ms;

--- a/css/effeckt.css
+++ b/css/effeckt.css
@@ -1307,6 +1307,7 @@ Example markup:
     .effeckt-off-screen-nav-left-squeeze.effeckt-off-screen-nav-show ~ [data-effeckt-page] {
       width: 60%; }
   .effeckt-off-screen-nav-left-squeeze ~ [data-effeckt-page] {
+    float: right;
     transition: width 500ms;
     max-width: none; }
 

--- a/css/modules/off-screen-nav.autoprefixed.css
+++ b/css/modules/off-screen-nav.autoprefixed.css
@@ -121,6 +121,7 @@
 }
 
 .effeckt-off-screen-nav-left-squeeze ~ [data-effeckt-page] {
+  float: right;
   -webkit-transition: width 500ms;
   -o-transition: width 500ms;
   transition: width 500ms;

--- a/css/modules/off-screen-nav.css
+++ b/css/modules/off-screen-nav.css
@@ -47,6 +47,7 @@
     .effeckt-off-screen-nav-left-squeeze.effeckt-off-screen-nav-show ~ [data-effeckt-page] {
       width: 60%; }
   .effeckt-off-screen-nav-left-squeeze ~ [data-effeckt-page] {
+    float: right;
     transition: width 500ms;
     max-width: none; }
 

--- a/dist/assets/css/effeckt.autoprefixed.css
+++ b/dist/assets/css/effeckt.autoprefixed.css
@@ -3332,6 +3332,7 @@ Example markup:
 }
 
 .effeckt-off-screen-nav-left-squeeze ~ [data-effeckt-page] {
+  float: right;
   -webkit-transition: width 500ms;
   -o-transition: width 500ms;
   transition: width 500ms;

--- a/dist/assets/css/effeckt.css
+++ b/dist/assets/css/effeckt.css
@@ -1307,6 +1307,7 @@ Example markup:
     .effeckt-off-screen-nav-left-squeeze.effeckt-off-screen-nav-show ~ [data-effeckt-page] {
       width: 60%; }
   .effeckt-off-screen-nav-left-squeeze ~ [data-effeckt-page] {
+    float: right;
     transition: width 500ms;
     max-width: none; }
 

--- a/dist/assets/css/modules/off-screen-nav.autoprefixed.css
+++ b/dist/assets/css/modules/off-screen-nav.autoprefixed.css
@@ -121,6 +121,7 @@
 }
 
 .effeckt-off-screen-nav-left-squeeze ~ [data-effeckt-page] {
+  float: right;
   -webkit-transition: width 500ms;
   -o-transition: width 500ms;
   transition: width 500ms;

--- a/dist/assets/css/modules/off-screen-nav.css
+++ b/dist/assets/css/modules/off-screen-nav.css
@@ -47,6 +47,7 @@
     .effeckt-off-screen-nav-left-squeeze.effeckt-off-screen-nav-show ~ [data-effeckt-page] {
       width: 60%; }
   .effeckt-off-screen-nav-left-squeeze ~ [data-effeckt-page] {
+    float: right;
     transition: width 500ms;
     max-width: none; }
 

--- a/scss/modules/off-screen-nav.scss
+++ b/scss/modules/off-screen-nav.scss
@@ -86,6 +86,7 @@
     }
   }
   ~ [data-effeckt-page] {
+    float: right;
     transition: width $effeckt-off-screen-navigation-transition-duration;
     max-width: none; // reset from demo
   }


### PR DESCRIPTION
page was originally getting squeezed in the same direction as 'right squeeze'
