### PR TITLE
Add a fallback to non-webkit browser on forms-elements

### DIFF
--- a/css/effeckt.autoprefixed.css
+++ b/css/effeckt.autoprefixed.css
@@ -6118,102 +6118,104 @@ Example markup:
   top: 115%;
 }
 
-.effeckt-ckbox-ios7[type=checkbox],
-.effeckt-rdio-ios7[type=radio] {
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  box-shadow: inset 0px 0px 0px 1px #e6e6e6;
-  border-radius: 15px;
-  cursor: pointer;
-  display: inline-block;
-  height: 31px;
-  padding: 1px;
-  position: relative;
-  margin: 0px;
-  width: 52px;
-  -webkit-transition: all 0.3s ease-out;
-  -o-transition: all 0.3s ease-out;
-  transition: all 0.3s ease-out;
-  -webkit-transform: scale(1);
-  -ms-transform: scale(1);
-  -o-transform: scale(1);
-  transform: scale(1);
-  background: white;
-}
+@media screen and (-webkit-min-device-pixel-ratio: 0) {
+  .effeckt-ckbox-ios7[type=checkbox],
+  .effeckt-rdio-ios7[type=radio] {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    box-shadow: inset 0px 0px 0px 1px #e6e6e6;
+    border-radius: 15px;
+    cursor: pointer;
+    display: inline-block;
+    height: 31px;
+    padding: 1px;
+    position: relative;
+    margin: 0px;
+    width: 52px;
+    -webkit-transition: all 0.3s ease-out;
+    -o-transition: all 0.3s ease-out;
+    transition: all 0.3s ease-out;
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    -o-transform: scale(1);
+    transform: scale(1);
+    background: white;
+  }
 
-.effeckt-ckbox-ios7[type=checkbox]:checked,
-.effeckt-rdio-ios7:checked {
-  box-shadow: inset 0px 0px 0px 20px #666666;
-}
+  .effeckt-ckbox-ios7[type=checkbox]:checked,
+  .effeckt-rdio-ios7:checked {
+    box-shadow: inset 0px 0px 0px 20px #666666;
+  }
 
-.effeckt-ckbox-ios7[type=checkbox]:after,
-.effeckt-rdio-ios7[type=radio]:after {
-  box-shadow: 0px 2px 2px 1px rgba(0, 0, 0, 0.2);
-  border-radius: 15px;
-  content: '';
-  cursor: pointer;
-  height: 29px;
-  position: absolute;
-  width: 29px;
-  -webkit-transition: all 0.1s ease-in 0.1s;
-  -o-transition: all 0.1s ease-in 0.1s;
-  transition: all 0.1s ease-in 0.1s;
-  background: white;
-}
+  .effeckt-ckbox-ios7[type=checkbox]:after,
+  .effeckt-rdio-ios7[type=radio]:after {
+    box-shadow: 0px 2px 2px 1px rgba(0, 0, 0, 0.2);
+    border-radius: 15px;
+    content: '';
+    cursor: pointer;
+    height: 29px;
+    position: absolute;
+    width: 29px;
+    -webkit-transition: all 0.1s ease-in 0.1s;
+    -o-transition: all 0.1s ease-in 0.1s;
+    transition: all 0.1s ease-in 0.1s;
+    background: white;
+  }
 
-.effeckt-ckbox-ios7[type="checkbox"]:checked:after,
-.effeckt-rdio-ios7[type="radio"]:checked:after {
-  left: 22px;
-}
+  .effeckt-ckbox-ios7[type="checkbox"]:checked:after,
+  .effeckt-rdio-ios7[type="radio"]:checked:after {
+    left: 22px;
+  }
 
-.effeckt-ckbox-android[type=checkbox],
-.effeckt-rdio-android[type=radio] {
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  box-shadow: inset 0px 0px 0px 1px #e6e6e6;
-  border-radius: 1px;
-  cursor: pointer;
-  display: inline-block;
-  height: 21px;
-  padding: 1px;
-  position: relative;
-  margin: 0px;
-  width: 72px;
-  -webkit-transition: all 0.3s ease-out;
-  -o-transition: all 0.3s ease-out;
-  transition: all 0.3s ease-out;
-  -webkit-transform: scale(1);
-  -ms-transform: scale(1);
-  -o-transform: scale(1);
-  transform: scale(1);
-  background: #333333;
-}
+  .effeckt-ckbox-android[type=checkbox],
+  .effeckt-rdio-android[type=radio] {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    box-shadow: inset 0px 0px 0px 1px #e6e6e6;
+    border-radius: 1px;
+    cursor: pointer;
+    display: inline-block;
+    height: 21px;
+    padding: 1px;
+    position: relative;
+    margin: 0px;
+    width: 72px;
+    -webkit-transition: all 0.3s ease-out;
+    -o-transition: all 0.3s ease-out;
+    transition: all 0.3s ease-out;
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    -o-transform: scale(1);
+    transform: scale(1);
+    background: #333333;
+  }
 
-.effeckt-ckbox-android[type=checkbox]:checked,
-.effeckt-rdio-android:checked {
-  box-shadow: inset 0px 0px 0px 20px #666666;
-}
+  .effeckt-ckbox-android[type=checkbox]:checked,
+  .effeckt-rdio-android:checked {
+    box-shadow: inset 0px 0px 0px 20px #666666;
+  }
 
-.effeckt-ckbox-android[type=checkbox]:after,
-.effeckt-rdio-android[type=radio]:after {
-  box-shadow: 0px 0px 0px 0px;
-  border-radius: 1px;
-  content: '';
-  cursor: pointer;
-  height: 19px;
-  position: absolute;
-  width: 29px;
-  -webkit-transition: all 0.1s ease-in 0.1s;
-  -o-transition: all 0.1s ease-in 0.1s;
-  transition: all 0.1s ease-in 0.1s;
-  background: #4d4d4d;
-}
+  .effeckt-ckbox-android[type=checkbox]:after,
+  .effeckt-rdio-android[type=radio]:after {
+    box-shadow: 0px 0px 0px 0px;
+    border-radius: 1px;
+    content: '';
+    cursor: pointer;
+    height: 19px;
+    position: absolute;
+    width: 29px;
+    -webkit-transition: all 0.1s ease-in 0.1s;
+    -o-transition: all 0.1s ease-in 0.1s;
+    transition: all 0.1s ease-in 0.1s;
+    background: #4d4d4d;
+  }
 
-.effeckt-ckbox-android[type="checkbox"]:checked:after,
-.effeckt-rdio-android[type="radio"]:checked:after {
-  left: 43px;
+  .effeckt-ckbox-android[type="checkbox"]:checked:after,
+  .effeckt-rdio-android[type="radio"]:checked:after {
+    left: 43px;
+  }
 }
 
 .effeckt-tabs-wrap {

--- a/css/effeckt.css
+++ b/css/effeckt.css
@@ -2113,80 +2113,74 @@ Example markup:
 .effeckt-tooltip[data-effeckt-tooltip-type="bubble"][data-effeckt-tooltip-position="bottom"]:hover::before, .effeckt-tooltip[data-effeckt-tooltip-type="bubble"][data-effeckt-tooltip-position="bottom"]:hover::after {
   top: 115%; }
 
-.effeckt-ckbox-ios7[type=checkbox], .effeckt-rdio-ios7[type=radio] {
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  box-shadow: inset 0px 0px 0px 1px #e6e6e6;
-  border-radius: 15px;
-  cursor: pointer;
-  display: inline-block;
-  height: 31px;
-  padding: 1px;
-  position: relative;
-  margin: 0px;
-  width: 52px;
-  transition: all 0.3s ease-out;
-  transform: scale(1);
-  background: white; }
-
-.effeckt-ckbox-ios7[type=checkbox]:checked, .effeckt-rdio-ios7:checked {
-  box-shadow: inset 0px 0px 0px 20px #666666; }
-
-.effeckt-ckbox-ios7[type=checkbox]:after, .effeckt-rdio-ios7[type=radio]:after {
-  box-shadow: 0px 2px 2px 1px rgba(0, 0, 0, 0.2);
-  border-radius: 15px;
-  content: '';
-  cursor: pointer;
-  height: 29px;
-  position: absolute;
-  width: 29px;
-  transition: all 0.1s ease-in 0.1s;
-  background: white; }
-
-.effeckt-ckbox-ios7[type="checkbox"]:checked:after, .effeckt-rdio-ios7[type="radio"]:checked:after {
-  left: 22px; }
-
-.effeckt-ckbox-android[type=checkbox], .effeckt-rdio-android[type=radio] {
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  box-shadow: inset 0px 0px 0px 1px #e6e6e6;
-  border-radius: 1px;
-  cursor: pointer;
-  display: inline-block;
-  height: 21px;
-  padding: 1px;
-  position: relative;
-  margin: 0px;
-  width: 72px;
-  -webkit-transition: all 0.3s ease-out;
-  -o-transition: all 0.3s ease-out;
-  transition: all 0.3s ease-out;
-  -webkit-transform: scale(1);
-  -ms-transform: scale(1);
-  -o-transform: scale(1);
-  transform: scale(1);
-  background: #333333; }
-
-.effeckt-ckbox-android[type=checkbox]:checked, .effeckt-rdio-android:checked {
-  box-shadow: inset 0px 0px 0px 20px #666666; }
-
-.effeckt-ckbox-android[type=checkbox]:after, .effeckt-rdio-android[type=radio]:after {
-  box-shadow: 0px 0px 0px 0px;
-  border-radius: 1px;
-  content: '';
-  cursor: pointer;
-  height: 19px;
-  position: absolute;
-  width: 29px;
-  -webkit-transition: all 0.1s ease-in 0.1s;
-  -o-transition: all 0.1s ease-in 0.1s;
-  transition: all 0.1s ease-in 0.1s;
-  background: #4d4d4d; }
-
-.effeckt-ckbox-android[type="checkbox"]:checked:after, .effeckt-rdio-android[type="radio"]:checked:after {
-  left: 43px; }
+@media screen and (-webkit-min-device-pixel-ratio: 0) {
+  .effeckt-ckbox-ios7[type=checkbox], .effeckt-rdio-ios7[type=radio] {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    box-shadow: inset 0px 0px 0px 1px #e6e6e6;
+    border-radius: 15px;
+    cursor: pointer;
+    display: inline-block;
+    height: 31px;
+    padding: 1px;
+    position: relative;
+    margin: 0px;
+    width: 52px;
+    transition: all 0.3s ease-out;
+    transform: scale(1);
+    background: white; }
+  .effeckt-ckbox-ios7[type=checkbox]:checked, .effeckt-rdio-ios7:checked {
+    box-shadow: inset 0px 0px 0px 20px #666666; }
+  .effeckt-ckbox-ios7[type=checkbox]:after, .effeckt-rdio-ios7[type=radio]:after {
+    box-shadow: 0px 2px 2px 1px rgba(0, 0, 0, 0.2);
+    border-radius: 15px;
+    content: '';
+    cursor: pointer;
+    height: 29px;
+    position: absolute;
+    width: 29px;
+    transition: all 0.1s ease-in 0.1s;
+    background: white; }
+  .effeckt-ckbox-ios7[type="checkbox"]:checked:after, .effeckt-rdio-ios7[type="radio"]:checked:after {
+    left: 22px; }
+  .effeckt-ckbox-android[type=checkbox], .effeckt-rdio-android[type=radio] {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    box-shadow: inset 0px 0px 0px 1px #e6e6e6;
+    border-radius: 1px;
+    cursor: pointer;
+    display: inline-block;
+    height: 21px;
+    padding: 1px;
+    position: relative;
+    margin: 0px;
+    width: 72px;
+    -webkit-transition: all 0.3s ease-out;
+    -o-transition: all 0.3s ease-out;
+    transition: all 0.3s ease-out;
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    -o-transform: scale(1);
+    transform: scale(1);
+    background: #333333; }
+  .effeckt-ckbox-android[type=checkbox]:checked, .effeckt-rdio-android:checked {
+    box-shadow: inset 0px 0px 0px 20px #666666; }
+  .effeckt-ckbox-android[type=checkbox]:after, .effeckt-rdio-android[type=radio]:after {
+    box-shadow: 0px 0px 0px 0px;
+    border-radius: 1px;
+    content: '';
+    cursor: pointer;
+    height: 19px;
+    position: absolute;
+    width: 29px;
+    -webkit-transition: all 0.1s ease-in 0.1s;
+    -o-transition: all 0.1s ease-in 0.1s;
+    transition: all 0.1s ease-in 0.1s;
+    background: #4d4d4d; }
+  .effeckt-ckbox-android[type="checkbox"]:checked:after, .effeckt-rdio-android[type="radio"]:checked:after {
+    left: 43px; } }
 
 .effeckt-tabs-wrap {
   position: relative; }

--- a/css/modules/form-elements.autoprefixed.css
+++ b/css/modules/form-elements.autoprefixed.css
@@ -1,97 +1,99 @@
-.effeckt-ckbox-ios7[type=checkbox],
-.effeckt-rdio-ios7[type=radio] {
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  box-shadow: inset 0px 0px 0px 1px #e6e6e6;
-  border-radius: 15px;
-  cursor: pointer;
-  display: inline-block;
-  height: 31px;
-  padding: 1px;
-  position: relative;
-  margin: 0px;
-  width: 52px;
-  -webkit-transition: all 0.3s ease-out;
-  -o-transition: all 0.3s ease-out;
-  transition: all 0.3s ease-out;
-  -webkit-transform: scale(1);
-  -ms-transform: scale(1);
-  -o-transform: scale(1);
-  transform: scale(1);
-  background: white;
-}
+@media screen and (-webkit-min-device-pixel-ratio: 0) {
+  .effeckt-ckbox-ios7[type=checkbox],
+  .effeckt-rdio-ios7[type=radio] {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    box-shadow: inset 0px 0px 0px 1px #e6e6e6;
+    border-radius: 15px;
+    cursor: pointer;
+    display: inline-block;
+    height: 31px;
+    padding: 1px;
+    position: relative;
+    margin: 0px;
+    width: 52px;
+    -webkit-transition: all 0.3s ease-out;
+    -o-transition: all 0.3s ease-out;
+    transition: all 0.3s ease-out;
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    -o-transform: scale(1);
+    transform: scale(1);
+    background: white;
+  }
 
-.effeckt-ckbox-ios7[type=checkbox]:checked,
-.effeckt-rdio-ios7:checked {
-  box-shadow: inset 0px 0px 0px 20px #666666;
-}
+  .effeckt-ckbox-ios7[type=checkbox]:checked,
+  .effeckt-rdio-ios7:checked {
+    box-shadow: inset 0px 0px 0px 20px #666666;
+  }
 
-.effeckt-ckbox-ios7[type=checkbox]:after,
-.effeckt-rdio-ios7[type=radio]:after {
-  box-shadow: 0px 2px 2px 1px rgba(0, 0, 0, 0.2);
-  border-radius: 15px;
-  content: '';
-  cursor: pointer;
-  height: 29px;
-  position: absolute;
-  width: 29px;
-  -webkit-transition: all 0.1s ease-in 0.1s;
-  -o-transition: all 0.1s ease-in 0.1s;
-  transition: all 0.1s ease-in 0.1s;
-  background: white;
-}
+  .effeckt-ckbox-ios7[type=checkbox]:after,
+  .effeckt-rdio-ios7[type=radio]:after {
+    box-shadow: 0px 2px 2px 1px rgba(0, 0, 0, 0.2);
+    border-radius: 15px;
+    content: '';
+    cursor: pointer;
+    height: 29px;
+    position: absolute;
+    width: 29px;
+    -webkit-transition: all 0.1s ease-in 0.1s;
+    -o-transition: all 0.1s ease-in 0.1s;
+    transition: all 0.1s ease-in 0.1s;
+    background: white;
+  }
 
-.effeckt-ckbox-ios7[type="checkbox"]:checked:after,
-.effeckt-rdio-ios7[type="radio"]:checked:after {
-  left: 22px;
-}
+  .effeckt-ckbox-ios7[type="checkbox"]:checked:after,
+  .effeckt-rdio-ios7[type="radio"]:checked:after {
+    left: 22px;
+  }
 
-.effeckt-ckbox-android[type=checkbox],
-.effeckt-rdio-android[type=radio] {
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  box-shadow: inset 0px 0px 0px 1px #e6e6e6;
-  border-radius: 1px;
-  cursor: pointer;
-  display: inline-block;
-  height: 21px;
-  padding: 1px;
-  position: relative;
-  margin: 0px;
-  width: 72px;
-  -webkit-transition: all 0.3s ease-out;
-  -o-transition: all 0.3s ease-out;
-  transition: all 0.3s ease-out;
-  -webkit-transform: scale(1);
-  -ms-transform: scale(1);
-  -o-transform: scale(1);
-  transform: scale(1);
-  background: #333333;
-}
+  .effeckt-ckbox-android[type=checkbox],
+  .effeckt-rdio-android[type=radio] {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    box-shadow: inset 0px 0px 0px 1px #e6e6e6;
+    border-radius: 1px;
+    cursor: pointer;
+    display: inline-block;
+    height: 21px;
+    padding: 1px;
+    position: relative;
+    margin: 0px;
+    width: 72px;
+    -webkit-transition: all 0.3s ease-out;
+    -o-transition: all 0.3s ease-out;
+    transition: all 0.3s ease-out;
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    -o-transform: scale(1);
+    transform: scale(1);
+    background: #333333;
+  }
 
-.effeckt-ckbox-android[type=checkbox]:checked,
-.effeckt-rdio-android:checked {
-  box-shadow: inset 0px 0px 0px 20px #666666;
-}
+  .effeckt-ckbox-android[type=checkbox]:checked,
+  .effeckt-rdio-android:checked {
+    box-shadow: inset 0px 0px 0px 20px #666666;
+  }
 
-.effeckt-ckbox-android[type=checkbox]:after,
-.effeckt-rdio-android[type=radio]:after {
-  box-shadow: 0px 0px 0px 0px;
-  border-radius: 1px;
-  content: '';
-  cursor: pointer;
-  height: 19px;
-  position: absolute;
-  width: 29px;
-  -webkit-transition: all 0.1s ease-in 0.1s;
-  -o-transition: all 0.1s ease-in 0.1s;
-  transition: all 0.1s ease-in 0.1s;
-  background: #4d4d4d;
-}
+  .effeckt-ckbox-android[type=checkbox]:after,
+  .effeckt-rdio-android[type=radio]:after {
+    box-shadow: 0px 0px 0px 0px;
+    border-radius: 1px;
+    content: '';
+    cursor: pointer;
+    height: 19px;
+    position: absolute;
+    width: 29px;
+    -webkit-transition: all 0.1s ease-in 0.1s;
+    -o-transition: all 0.1s ease-in 0.1s;
+    transition: all 0.1s ease-in 0.1s;
+    background: #4d4d4d;
+  }
 
-.effeckt-ckbox-android[type="checkbox"]:checked:after,
-.effeckt-rdio-android[type="radio"]:checked:after {
-  left: 43px;
+  .effeckt-ckbox-android[type="checkbox"]:checked:after,
+  .effeckt-rdio-android[type="radio"]:checked:after {
+    left: 43px;
+  }
 }

--- a/css/modules/form-elements.css
+++ b/css/modules/form-elements.css
@@ -1,74 +1,68 @@
-.effeckt-ckbox-ios7[type=checkbox], .effeckt-rdio-ios7[type=radio] {
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  box-shadow: inset 0px 0px 0px 1px #e6e6e6;
-  border-radius: 15px;
-  cursor: pointer;
-  display: inline-block;
-  height: 31px;
-  padding: 1px;
-  position: relative;
-  margin: 0px;
-  width: 52px;
-  transition: all 0.3s ease-out;
-  transform: scale(1);
-  background: white; }
-
-.effeckt-ckbox-ios7[type=checkbox]:checked, .effeckt-rdio-ios7:checked {
-  box-shadow: inset 0px 0px 0px 20px #666666; }
-
-.effeckt-ckbox-ios7[type=checkbox]:after, .effeckt-rdio-ios7[type=radio]:after {
-  box-shadow: 0px 2px 2px 1px rgba(0, 0, 0, 0.2);
-  border-radius: 15px;
-  content: '';
-  cursor: pointer;
-  height: 29px;
-  position: absolute;
-  width: 29px;
-  transition: all 0.1s ease-in 0.1s;
-  background: white; }
-
-.effeckt-ckbox-ios7[type="checkbox"]:checked:after, .effeckt-rdio-ios7[type="radio"]:checked:after {
-  left: 22px; }
-
-.effeckt-ckbox-android[type=checkbox], .effeckt-rdio-android[type=radio] {
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  box-shadow: inset 0px 0px 0px 1px #e6e6e6;
-  border-radius: 1px;
-  cursor: pointer;
-  display: inline-block;
-  height: 21px;
-  padding: 1px;
-  position: relative;
-  margin: 0px;
-  width: 72px;
-  -webkit-transition: all 0.3s ease-out;
-  -o-transition: all 0.3s ease-out;
-  transition: all 0.3s ease-out;
-  -webkit-transform: scale(1);
-  -ms-transform: scale(1);
-  -o-transform: scale(1);
-  transform: scale(1);
-  background: #333333; }
-
-.effeckt-ckbox-android[type=checkbox]:checked, .effeckt-rdio-android:checked {
-  box-shadow: inset 0px 0px 0px 20px #666666; }
-
-.effeckt-ckbox-android[type=checkbox]:after, .effeckt-rdio-android[type=radio]:after {
-  box-shadow: 0px 0px 0px 0px;
-  border-radius: 1px;
-  content: '';
-  cursor: pointer;
-  height: 19px;
-  position: absolute;
-  width: 29px;
-  -webkit-transition: all 0.1s ease-in 0.1s;
-  -o-transition: all 0.1s ease-in 0.1s;
-  transition: all 0.1s ease-in 0.1s;
-  background: #4d4d4d; }
-
-.effeckt-ckbox-android[type="checkbox"]:checked:after, .effeckt-rdio-android[type="radio"]:checked:after {
-  left: 43px; }
+@media screen and (-webkit-min-device-pixel-ratio: 0) {
+  .effeckt-ckbox-ios7[type=checkbox], .effeckt-rdio-ios7[type=radio] {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    box-shadow: inset 0px 0px 0px 1px #e6e6e6;
+    border-radius: 15px;
+    cursor: pointer;
+    display: inline-block;
+    height: 31px;
+    padding: 1px;
+    position: relative;
+    margin: 0px;
+    width: 52px;
+    transition: all 0.3s ease-out;
+    transform: scale(1);
+    background: white; }
+  .effeckt-ckbox-ios7[type=checkbox]:checked, .effeckt-rdio-ios7:checked {
+    box-shadow: inset 0px 0px 0px 20px #666666; }
+  .effeckt-ckbox-ios7[type=checkbox]:after, .effeckt-rdio-ios7[type=radio]:after {
+    box-shadow: 0px 2px 2px 1px rgba(0, 0, 0, 0.2);
+    border-radius: 15px;
+    content: '';
+    cursor: pointer;
+    height: 29px;
+    position: absolute;
+    width: 29px;
+    transition: all 0.1s ease-in 0.1s;
+    background: white; }
+  .effeckt-ckbox-ios7[type="checkbox"]:checked:after, .effeckt-rdio-ios7[type="radio"]:checked:after {
+    left: 22px; }
+  .effeckt-ckbox-android[type=checkbox], .effeckt-rdio-android[type=radio] {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    box-shadow: inset 0px 0px 0px 1px #e6e6e6;
+    border-radius: 1px;
+    cursor: pointer;
+    display: inline-block;
+    height: 21px;
+    padding: 1px;
+    position: relative;
+    margin: 0px;
+    width: 72px;
+    -webkit-transition: all 0.3s ease-out;
+    -o-transition: all 0.3s ease-out;
+    transition: all 0.3s ease-out;
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    -o-transform: scale(1);
+    transform: scale(1);
+    background: #333333; }
+  .effeckt-ckbox-android[type=checkbox]:checked, .effeckt-rdio-android:checked {
+    box-shadow: inset 0px 0px 0px 20px #666666; }
+  .effeckt-ckbox-android[type=checkbox]:after, .effeckt-rdio-android[type=radio]:after {
+    box-shadow: 0px 0px 0px 0px;
+    border-radius: 1px;
+    content: '';
+    cursor: pointer;
+    height: 19px;
+    position: absolute;
+    width: 29px;
+    -webkit-transition: all 0.1s ease-in 0.1s;
+    -o-transition: all 0.1s ease-in 0.1s;
+    transition: all 0.1s ease-in 0.1s;
+    background: #4d4d4d; }
+  .effeckt-ckbox-android[type="checkbox"]:checked:after, .effeckt-rdio-android[type="radio"]:checked:after {
+    left: 43px; } }

--- a/dist/assets/css/effeckt.autoprefixed.css
+++ b/dist/assets/css/effeckt.autoprefixed.css
@@ -6118,102 +6118,104 @@ Example markup:
   top: 115%;
 }
 
-.effeckt-ckbox-ios7[type=checkbox],
-.effeckt-rdio-ios7[type=radio] {
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  box-shadow: inset 0px 0px 0px 1px #e6e6e6;
-  border-radius: 15px;
-  cursor: pointer;
-  display: inline-block;
-  height: 31px;
-  padding: 1px;
-  position: relative;
-  margin: 0px;
-  width: 52px;
-  -webkit-transition: all 0.3s ease-out;
-  -o-transition: all 0.3s ease-out;
-  transition: all 0.3s ease-out;
-  -webkit-transform: scale(1);
-  -ms-transform: scale(1);
-  -o-transform: scale(1);
-  transform: scale(1);
-  background: white;
-}
+@media screen and (-webkit-min-device-pixel-ratio: 0) {
+  .effeckt-ckbox-ios7[type=checkbox],
+  .effeckt-rdio-ios7[type=radio] {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    box-shadow: inset 0px 0px 0px 1px #e6e6e6;
+    border-radius: 15px;
+    cursor: pointer;
+    display: inline-block;
+    height: 31px;
+    padding: 1px;
+    position: relative;
+    margin: 0px;
+    width: 52px;
+    -webkit-transition: all 0.3s ease-out;
+    -o-transition: all 0.3s ease-out;
+    transition: all 0.3s ease-out;
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    -o-transform: scale(1);
+    transform: scale(1);
+    background: white;
+  }
 
-.effeckt-ckbox-ios7[type=checkbox]:checked,
-.effeckt-rdio-ios7:checked {
-  box-shadow: inset 0px 0px 0px 20px #666666;
-}
+  .effeckt-ckbox-ios7[type=checkbox]:checked,
+  .effeckt-rdio-ios7:checked {
+    box-shadow: inset 0px 0px 0px 20px #666666;
+  }
 
-.effeckt-ckbox-ios7[type=checkbox]:after,
-.effeckt-rdio-ios7[type=radio]:after {
-  box-shadow: 0px 2px 2px 1px rgba(0, 0, 0, 0.2);
-  border-radius: 15px;
-  content: '';
-  cursor: pointer;
-  height: 29px;
-  position: absolute;
-  width: 29px;
-  -webkit-transition: all 0.1s ease-in 0.1s;
-  -o-transition: all 0.1s ease-in 0.1s;
-  transition: all 0.1s ease-in 0.1s;
-  background: white;
-}
+  .effeckt-ckbox-ios7[type=checkbox]:after,
+  .effeckt-rdio-ios7[type=radio]:after {
+    box-shadow: 0px 2px 2px 1px rgba(0, 0, 0, 0.2);
+    border-radius: 15px;
+    content: '';
+    cursor: pointer;
+    height: 29px;
+    position: absolute;
+    width: 29px;
+    -webkit-transition: all 0.1s ease-in 0.1s;
+    -o-transition: all 0.1s ease-in 0.1s;
+    transition: all 0.1s ease-in 0.1s;
+    background: white;
+  }
 
-.effeckt-ckbox-ios7[type="checkbox"]:checked:after,
-.effeckt-rdio-ios7[type="radio"]:checked:after {
-  left: 22px;
-}
+  .effeckt-ckbox-ios7[type="checkbox"]:checked:after,
+  .effeckt-rdio-ios7[type="radio"]:checked:after {
+    left: 22px;
+  }
 
-.effeckt-ckbox-android[type=checkbox],
-.effeckt-rdio-android[type=radio] {
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  box-shadow: inset 0px 0px 0px 1px #e6e6e6;
-  border-radius: 1px;
-  cursor: pointer;
-  display: inline-block;
-  height: 21px;
-  padding: 1px;
-  position: relative;
-  margin: 0px;
-  width: 72px;
-  -webkit-transition: all 0.3s ease-out;
-  -o-transition: all 0.3s ease-out;
-  transition: all 0.3s ease-out;
-  -webkit-transform: scale(1);
-  -ms-transform: scale(1);
-  -o-transform: scale(1);
-  transform: scale(1);
-  background: #333333;
-}
+  .effeckt-ckbox-android[type=checkbox],
+  .effeckt-rdio-android[type=radio] {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    box-shadow: inset 0px 0px 0px 1px #e6e6e6;
+    border-radius: 1px;
+    cursor: pointer;
+    display: inline-block;
+    height: 21px;
+    padding: 1px;
+    position: relative;
+    margin: 0px;
+    width: 72px;
+    -webkit-transition: all 0.3s ease-out;
+    -o-transition: all 0.3s ease-out;
+    transition: all 0.3s ease-out;
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    -o-transform: scale(1);
+    transform: scale(1);
+    background: #333333;
+  }
 
-.effeckt-ckbox-android[type=checkbox]:checked,
-.effeckt-rdio-android:checked {
-  box-shadow: inset 0px 0px 0px 20px #666666;
-}
+  .effeckt-ckbox-android[type=checkbox]:checked,
+  .effeckt-rdio-android:checked {
+    box-shadow: inset 0px 0px 0px 20px #666666;
+  }
 
-.effeckt-ckbox-android[type=checkbox]:after,
-.effeckt-rdio-android[type=radio]:after {
-  box-shadow: 0px 0px 0px 0px;
-  border-radius: 1px;
-  content: '';
-  cursor: pointer;
-  height: 19px;
-  position: absolute;
-  width: 29px;
-  -webkit-transition: all 0.1s ease-in 0.1s;
-  -o-transition: all 0.1s ease-in 0.1s;
-  transition: all 0.1s ease-in 0.1s;
-  background: #4d4d4d;
-}
+  .effeckt-ckbox-android[type=checkbox]:after,
+  .effeckt-rdio-android[type=radio]:after {
+    box-shadow: 0px 0px 0px 0px;
+    border-radius: 1px;
+    content: '';
+    cursor: pointer;
+    height: 19px;
+    position: absolute;
+    width: 29px;
+    -webkit-transition: all 0.1s ease-in 0.1s;
+    -o-transition: all 0.1s ease-in 0.1s;
+    transition: all 0.1s ease-in 0.1s;
+    background: #4d4d4d;
+  }
 
-.effeckt-ckbox-android[type="checkbox"]:checked:after,
-.effeckt-rdio-android[type="radio"]:checked:after {
-  left: 43px;
+  .effeckt-ckbox-android[type="checkbox"]:checked:after,
+  .effeckt-rdio-android[type="radio"]:checked:after {
+    left: 43px;
+  }
 }
 
 .effeckt-tabs-wrap {

--- a/dist/assets/css/effeckt.css
+++ b/dist/assets/css/effeckt.css
@@ -2113,80 +2113,74 @@ Example markup:
 .effeckt-tooltip[data-effeckt-tooltip-type="bubble"][data-effeckt-tooltip-position="bottom"]:hover::before, .effeckt-tooltip[data-effeckt-tooltip-type="bubble"][data-effeckt-tooltip-position="bottom"]:hover::after {
   top: 115%; }
 
-.effeckt-ckbox-ios7[type=checkbox], .effeckt-rdio-ios7[type=radio] {
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  box-shadow: inset 0px 0px 0px 1px #e6e6e6;
-  border-radius: 15px;
-  cursor: pointer;
-  display: inline-block;
-  height: 31px;
-  padding: 1px;
-  position: relative;
-  margin: 0px;
-  width: 52px;
-  transition: all 0.3s ease-out;
-  transform: scale(1);
-  background: white; }
-
-.effeckt-ckbox-ios7[type=checkbox]:checked, .effeckt-rdio-ios7:checked {
-  box-shadow: inset 0px 0px 0px 20px #666666; }
-
-.effeckt-ckbox-ios7[type=checkbox]:after, .effeckt-rdio-ios7[type=radio]:after {
-  box-shadow: 0px 2px 2px 1px rgba(0, 0, 0, 0.2);
-  border-radius: 15px;
-  content: '';
-  cursor: pointer;
-  height: 29px;
-  position: absolute;
-  width: 29px;
-  transition: all 0.1s ease-in 0.1s;
-  background: white; }
-
-.effeckt-ckbox-ios7[type="checkbox"]:checked:after, .effeckt-rdio-ios7[type="radio"]:checked:after {
-  left: 22px; }
-
-.effeckt-ckbox-android[type=checkbox], .effeckt-rdio-android[type=radio] {
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  box-shadow: inset 0px 0px 0px 1px #e6e6e6;
-  border-radius: 1px;
-  cursor: pointer;
-  display: inline-block;
-  height: 21px;
-  padding: 1px;
-  position: relative;
-  margin: 0px;
-  width: 72px;
-  -webkit-transition: all 0.3s ease-out;
-  -o-transition: all 0.3s ease-out;
-  transition: all 0.3s ease-out;
-  -webkit-transform: scale(1);
-  -ms-transform: scale(1);
-  -o-transform: scale(1);
-  transform: scale(1);
-  background: #333333; }
-
-.effeckt-ckbox-android[type=checkbox]:checked, .effeckt-rdio-android:checked {
-  box-shadow: inset 0px 0px 0px 20px #666666; }
-
-.effeckt-ckbox-android[type=checkbox]:after, .effeckt-rdio-android[type=radio]:after {
-  box-shadow: 0px 0px 0px 0px;
-  border-radius: 1px;
-  content: '';
-  cursor: pointer;
-  height: 19px;
-  position: absolute;
-  width: 29px;
-  -webkit-transition: all 0.1s ease-in 0.1s;
-  -o-transition: all 0.1s ease-in 0.1s;
-  transition: all 0.1s ease-in 0.1s;
-  background: #4d4d4d; }
-
-.effeckt-ckbox-android[type="checkbox"]:checked:after, .effeckt-rdio-android[type="radio"]:checked:after {
-  left: 43px; }
+@media screen and (-webkit-min-device-pixel-ratio: 0) {
+  .effeckt-ckbox-ios7[type=checkbox], .effeckt-rdio-ios7[type=radio] {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    box-shadow: inset 0px 0px 0px 1px #e6e6e6;
+    border-radius: 15px;
+    cursor: pointer;
+    display: inline-block;
+    height: 31px;
+    padding: 1px;
+    position: relative;
+    margin: 0px;
+    width: 52px;
+    transition: all 0.3s ease-out;
+    transform: scale(1);
+    background: white; }
+  .effeckt-ckbox-ios7[type=checkbox]:checked, .effeckt-rdio-ios7:checked {
+    box-shadow: inset 0px 0px 0px 20px #666666; }
+  .effeckt-ckbox-ios7[type=checkbox]:after, .effeckt-rdio-ios7[type=radio]:after {
+    box-shadow: 0px 2px 2px 1px rgba(0, 0, 0, 0.2);
+    border-radius: 15px;
+    content: '';
+    cursor: pointer;
+    height: 29px;
+    position: absolute;
+    width: 29px;
+    transition: all 0.1s ease-in 0.1s;
+    background: white; }
+  .effeckt-ckbox-ios7[type="checkbox"]:checked:after, .effeckt-rdio-ios7[type="radio"]:checked:after {
+    left: 22px; }
+  .effeckt-ckbox-android[type=checkbox], .effeckt-rdio-android[type=radio] {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    box-shadow: inset 0px 0px 0px 1px #e6e6e6;
+    border-radius: 1px;
+    cursor: pointer;
+    display: inline-block;
+    height: 21px;
+    padding: 1px;
+    position: relative;
+    margin: 0px;
+    width: 72px;
+    -webkit-transition: all 0.3s ease-out;
+    -o-transition: all 0.3s ease-out;
+    transition: all 0.3s ease-out;
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    -o-transform: scale(1);
+    transform: scale(1);
+    background: #333333; }
+  .effeckt-ckbox-android[type=checkbox]:checked, .effeckt-rdio-android:checked {
+    box-shadow: inset 0px 0px 0px 20px #666666; }
+  .effeckt-ckbox-android[type=checkbox]:after, .effeckt-rdio-android[type=radio]:after {
+    box-shadow: 0px 0px 0px 0px;
+    border-radius: 1px;
+    content: '';
+    cursor: pointer;
+    height: 19px;
+    position: absolute;
+    width: 29px;
+    -webkit-transition: all 0.1s ease-in 0.1s;
+    -o-transition: all 0.1s ease-in 0.1s;
+    transition: all 0.1s ease-in 0.1s;
+    background: #4d4d4d; }
+  .effeckt-ckbox-android[type="checkbox"]:checked:after, .effeckt-rdio-android[type="radio"]:checked:after {
+    left: 43px; } }
 
 .effeckt-tabs-wrap {
   position: relative; }

--- a/dist/assets/css/modules/form-elements.autoprefixed.css
+++ b/dist/assets/css/modules/form-elements.autoprefixed.css
@@ -1,97 +1,99 @@
-.effeckt-ckbox-ios7[type=checkbox],
-.effeckt-rdio-ios7[type=radio] {
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  box-shadow: inset 0px 0px 0px 1px #e6e6e6;
-  border-radius: 15px;
-  cursor: pointer;
-  display: inline-block;
-  height: 31px;
-  padding: 1px;
-  position: relative;
-  margin: 0px;
-  width: 52px;
-  -webkit-transition: all 0.3s ease-out;
-  -o-transition: all 0.3s ease-out;
-  transition: all 0.3s ease-out;
-  -webkit-transform: scale(1);
-  -ms-transform: scale(1);
-  -o-transform: scale(1);
-  transform: scale(1);
-  background: white;
-}
+@media screen and (-webkit-min-device-pixel-ratio: 0) {
+  .effeckt-ckbox-ios7[type=checkbox],
+  .effeckt-rdio-ios7[type=radio] {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    box-shadow: inset 0px 0px 0px 1px #e6e6e6;
+    border-radius: 15px;
+    cursor: pointer;
+    display: inline-block;
+    height: 31px;
+    padding: 1px;
+    position: relative;
+    margin: 0px;
+    width: 52px;
+    -webkit-transition: all 0.3s ease-out;
+    -o-transition: all 0.3s ease-out;
+    transition: all 0.3s ease-out;
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    -o-transform: scale(1);
+    transform: scale(1);
+    background: white;
+  }
 
-.effeckt-ckbox-ios7[type=checkbox]:checked,
-.effeckt-rdio-ios7:checked {
-  box-shadow: inset 0px 0px 0px 20px #666666;
-}
+  .effeckt-ckbox-ios7[type=checkbox]:checked,
+  .effeckt-rdio-ios7:checked {
+    box-shadow: inset 0px 0px 0px 20px #666666;
+  }
 
-.effeckt-ckbox-ios7[type=checkbox]:after,
-.effeckt-rdio-ios7[type=radio]:after {
-  box-shadow: 0px 2px 2px 1px rgba(0, 0, 0, 0.2);
-  border-radius: 15px;
-  content: '';
-  cursor: pointer;
-  height: 29px;
-  position: absolute;
-  width: 29px;
-  -webkit-transition: all 0.1s ease-in 0.1s;
-  -o-transition: all 0.1s ease-in 0.1s;
-  transition: all 0.1s ease-in 0.1s;
-  background: white;
-}
+  .effeckt-ckbox-ios7[type=checkbox]:after,
+  .effeckt-rdio-ios7[type=radio]:after {
+    box-shadow: 0px 2px 2px 1px rgba(0, 0, 0, 0.2);
+    border-radius: 15px;
+    content: '';
+    cursor: pointer;
+    height: 29px;
+    position: absolute;
+    width: 29px;
+    -webkit-transition: all 0.1s ease-in 0.1s;
+    -o-transition: all 0.1s ease-in 0.1s;
+    transition: all 0.1s ease-in 0.1s;
+    background: white;
+  }
 
-.effeckt-ckbox-ios7[type="checkbox"]:checked:after,
-.effeckt-rdio-ios7[type="radio"]:checked:after {
-  left: 22px;
-}
+  .effeckt-ckbox-ios7[type="checkbox"]:checked:after,
+  .effeckt-rdio-ios7[type="radio"]:checked:after {
+    left: 22px;
+  }
 
-.effeckt-ckbox-android[type=checkbox],
-.effeckt-rdio-android[type=radio] {
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  box-shadow: inset 0px 0px 0px 1px #e6e6e6;
-  border-radius: 1px;
-  cursor: pointer;
-  display: inline-block;
-  height: 21px;
-  padding: 1px;
-  position: relative;
-  margin: 0px;
-  width: 72px;
-  -webkit-transition: all 0.3s ease-out;
-  -o-transition: all 0.3s ease-out;
-  transition: all 0.3s ease-out;
-  -webkit-transform: scale(1);
-  -ms-transform: scale(1);
-  -o-transform: scale(1);
-  transform: scale(1);
-  background: #333333;
-}
+  .effeckt-ckbox-android[type=checkbox],
+  .effeckt-rdio-android[type=radio] {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    box-shadow: inset 0px 0px 0px 1px #e6e6e6;
+    border-radius: 1px;
+    cursor: pointer;
+    display: inline-block;
+    height: 21px;
+    padding: 1px;
+    position: relative;
+    margin: 0px;
+    width: 72px;
+    -webkit-transition: all 0.3s ease-out;
+    -o-transition: all 0.3s ease-out;
+    transition: all 0.3s ease-out;
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    -o-transform: scale(1);
+    transform: scale(1);
+    background: #333333;
+  }
 
-.effeckt-ckbox-android[type=checkbox]:checked,
-.effeckt-rdio-android:checked {
-  box-shadow: inset 0px 0px 0px 20px #666666;
-}
+  .effeckt-ckbox-android[type=checkbox]:checked,
+  .effeckt-rdio-android:checked {
+    box-shadow: inset 0px 0px 0px 20px #666666;
+  }
 
-.effeckt-ckbox-android[type=checkbox]:after,
-.effeckt-rdio-android[type=radio]:after {
-  box-shadow: 0px 0px 0px 0px;
-  border-radius: 1px;
-  content: '';
-  cursor: pointer;
-  height: 19px;
-  position: absolute;
-  width: 29px;
-  -webkit-transition: all 0.1s ease-in 0.1s;
-  -o-transition: all 0.1s ease-in 0.1s;
-  transition: all 0.1s ease-in 0.1s;
-  background: #4d4d4d;
-}
+  .effeckt-ckbox-android[type=checkbox]:after,
+  .effeckt-rdio-android[type=radio]:after {
+    box-shadow: 0px 0px 0px 0px;
+    border-radius: 1px;
+    content: '';
+    cursor: pointer;
+    height: 19px;
+    position: absolute;
+    width: 29px;
+    -webkit-transition: all 0.1s ease-in 0.1s;
+    -o-transition: all 0.1s ease-in 0.1s;
+    transition: all 0.1s ease-in 0.1s;
+    background: #4d4d4d;
+  }
 
-.effeckt-ckbox-android[type="checkbox"]:checked:after,
-.effeckt-rdio-android[type="radio"]:checked:after {
-  left: 43px;
+  .effeckt-ckbox-android[type="checkbox"]:checked:after,
+  .effeckt-rdio-android[type="radio"]:checked:after {
+    left: 43px;
+  }
 }

--- a/dist/assets/css/modules/form-elements.css
+++ b/dist/assets/css/modules/form-elements.css
@@ -1,74 +1,68 @@
-.effeckt-ckbox-ios7[type=checkbox], .effeckt-rdio-ios7[type=radio] {
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  box-shadow: inset 0px 0px 0px 1px #e6e6e6;
-  border-radius: 15px;
-  cursor: pointer;
-  display: inline-block;
-  height: 31px;
-  padding: 1px;
-  position: relative;
-  margin: 0px;
-  width: 52px;
-  transition: all 0.3s ease-out;
-  transform: scale(1);
-  background: white; }
-
-.effeckt-ckbox-ios7[type=checkbox]:checked, .effeckt-rdio-ios7:checked {
-  box-shadow: inset 0px 0px 0px 20px #666666; }
-
-.effeckt-ckbox-ios7[type=checkbox]:after, .effeckt-rdio-ios7[type=radio]:after {
-  box-shadow: 0px 2px 2px 1px rgba(0, 0, 0, 0.2);
-  border-radius: 15px;
-  content: '';
-  cursor: pointer;
-  height: 29px;
-  position: absolute;
-  width: 29px;
-  transition: all 0.1s ease-in 0.1s;
-  background: white; }
-
-.effeckt-ckbox-ios7[type="checkbox"]:checked:after, .effeckt-rdio-ios7[type="radio"]:checked:after {
-  left: 22px; }
-
-.effeckt-ckbox-android[type=checkbox], .effeckt-rdio-android[type=radio] {
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  box-shadow: inset 0px 0px 0px 1px #e6e6e6;
-  border-radius: 1px;
-  cursor: pointer;
-  display: inline-block;
-  height: 21px;
-  padding: 1px;
-  position: relative;
-  margin: 0px;
-  width: 72px;
-  -webkit-transition: all 0.3s ease-out;
-  -o-transition: all 0.3s ease-out;
-  transition: all 0.3s ease-out;
-  -webkit-transform: scale(1);
-  -ms-transform: scale(1);
-  -o-transform: scale(1);
-  transform: scale(1);
-  background: #333333; }
-
-.effeckt-ckbox-android[type=checkbox]:checked, .effeckt-rdio-android:checked {
-  box-shadow: inset 0px 0px 0px 20px #666666; }
-
-.effeckt-ckbox-android[type=checkbox]:after, .effeckt-rdio-android[type=radio]:after {
-  box-shadow: 0px 0px 0px 0px;
-  border-radius: 1px;
-  content: '';
-  cursor: pointer;
-  height: 19px;
-  position: absolute;
-  width: 29px;
-  -webkit-transition: all 0.1s ease-in 0.1s;
-  -o-transition: all 0.1s ease-in 0.1s;
-  transition: all 0.1s ease-in 0.1s;
-  background: #4d4d4d; }
-
-.effeckt-ckbox-android[type="checkbox"]:checked:after, .effeckt-rdio-android[type="radio"]:checked:after {
-  left: 43px; }
+@media screen and (-webkit-min-device-pixel-ratio: 0) {
+  .effeckt-ckbox-ios7[type=checkbox], .effeckt-rdio-ios7[type=radio] {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    box-shadow: inset 0px 0px 0px 1px #e6e6e6;
+    border-radius: 15px;
+    cursor: pointer;
+    display: inline-block;
+    height: 31px;
+    padding: 1px;
+    position: relative;
+    margin: 0px;
+    width: 52px;
+    transition: all 0.3s ease-out;
+    transform: scale(1);
+    background: white; }
+  .effeckt-ckbox-ios7[type=checkbox]:checked, .effeckt-rdio-ios7:checked {
+    box-shadow: inset 0px 0px 0px 20px #666666; }
+  .effeckt-ckbox-ios7[type=checkbox]:after, .effeckt-rdio-ios7[type=radio]:after {
+    box-shadow: 0px 2px 2px 1px rgba(0, 0, 0, 0.2);
+    border-radius: 15px;
+    content: '';
+    cursor: pointer;
+    height: 29px;
+    position: absolute;
+    width: 29px;
+    transition: all 0.1s ease-in 0.1s;
+    background: white; }
+  .effeckt-ckbox-ios7[type="checkbox"]:checked:after, .effeckt-rdio-ios7[type="radio"]:checked:after {
+    left: 22px; }
+  .effeckt-ckbox-android[type=checkbox], .effeckt-rdio-android[type=radio] {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    box-shadow: inset 0px 0px 0px 1px #e6e6e6;
+    border-radius: 1px;
+    cursor: pointer;
+    display: inline-block;
+    height: 21px;
+    padding: 1px;
+    position: relative;
+    margin: 0px;
+    width: 72px;
+    -webkit-transition: all 0.3s ease-out;
+    -o-transition: all 0.3s ease-out;
+    transition: all 0.3s ease-out;
+    -webkit-transform: scale(1);
+    -ms-transform: scale(1);
+    -o-transform: scale(1);
+    transform: scale(1);
+    background: #333333; }
+  .effeckt-ckbox-android[type=checkbox]:checked, .effeckt-rdio-android:checked {
+    box-shadow: inset 0px 0px 0px 20px #666666; }
+  .effeckt-ckbox-android[type=checkbox]:after, .effeckt-rdio-android[type=radio]:after {
+    box-shadow: 0px 0px 0px 0px;
+    border-radius: 1px;
+    content: '';
+    cursor: pointer;
+    height: 19px;
+    position: absolute;
+    width: 29px;
+    -webkit-transition: all 0.1s ease-in 0.1s;
+    -o-transition: all 0.1s ease-in 0.1s;
+    transition: all 0.1s ease-in 0.1s;
+    background: #4d4d4d; }
+  .effeckt-ckbox-android[type="checkbox"]:checked:after, .effeckt-rdio-android[type="radio"]:checked:after {
+    left: 43px; } }

--- a/scss/modules/form-elements.scss
+++ b/scss/modules/form-elements.scss
@@ -3,7 +3,12 @@
 // Notes: Only works in WebKit for now
 // is this acceptable to our goals?
 
-.effeckt-ckbox-ios7[type=checkbox],
+// Fallback
+// Apply this style only on WebKit
+// To prevent ugly styles on non-WebKit Browser
+@media screen and (-webkit-min-device-pixel-ratio:0) {
+  
+  .effeckt-ckbox-ios7[type=checkbox],
 .effeckt-rdio-ios7[type=radio] {
 
   // Not caught by autoprefixer
@@ -98,4 +103,6 @@
 .effeckt-ckbox-android[type="checkbox"]:checked:after,
 .effeckt-rdio-android[type="radio"]:checked:after {
   left: 43px;
+}
+
 }


### PR DESCRIPTION
This fix an issue mentioned here: https://github.com/h5bp/Effeckt.css/issues/196.
This prevent non-webkit browser to mess up the input style, so it uses default styles.
