### PR TITLE
Use new classes names on positional-modal.

### DIFF
--- a/dist/assets/js/modules/positional-modals.js
+++ b/dist/assets/js/modules/positional-modals.js
@@ -30,8 +30,8 @@ var EffecktPositionalModals = {
   openModal: function($el) {
 
     var self = this,
-        style = $el.data('effeckt-modal-style'),
-        position = $el.data('effeckt-positional-modal-type'),
+        style = $el.data('effeckt-type'),
+        position = $el.data('effeckt-positional-modal-position'),
         buttonPosition = $el.offset(),
         buttonSize = {
           'width': $el.outerWidth(),

--- a/dist/index.html
+++ b/dist/index.html
@@ -158,11 +158,11 @@
   </header>
 
   <div class="button-group">
-    <button class="effeckt-positional-modal-button" data-effeckt-positional-modal-type="above" data-effeckt-modal-style="md-effect-1">Above / From Below</button>
-    <button class="effeckt-positional-modal-button" data-effeckt-positional-modal-type="above" data-effeckt-modal-style="md-effect-5">Above / From Above</button>
-    <button class="effeckt-positional-modal-button" data-effeckt-positional-modal-type="above" data-effeckt-modal-style="md-effect-2">Above / Slide In (right)</button>
+    <button class="effeckt-positional-modal-button" data-effeckt-positional-modal-position="above" data-effeckt-type="from-below">Above / From Below</button>
+    <button class="effeckt-positional-modal-button" data-effeckt-positional-modal-position="above" data-effeckt-type="from-above">Above / From Above</button>
+    <button class="effeckt-positional-modal-button" data-effeckt-positional-modal-position="above" data-effeckt-type="slide-in-right">Above / Slide In (right)</button>
 
-    <button class="effeckt-positional-modal-button" data-effeckt-positional-modal-type="below" data-effeckt-modal-style="md-effect-1">Below / From Below</button>
+    <button class="effeckt-positional-modal-button" data-effeckt-positional-modal-position="below" data-effeckt-type="from-below">Below / From Below</button>
   </div>
 
 </div>

--- a/dist/positional-modals.html
+++ b/dist/positional-modals.html
@@ -105,11 +105,11 @@
   </header>
 
   <div class="button-group">
-    <button class="effeckt-positional-modal-button" data-effeckt-positional-modal-type="above" data-effeckt-modal-style="md-effect-1">Above / From Below</button>
-    <button class="effeckt-positional-modal-button" data-effeckt-positional-modal-type="above" data-effeckt-modal-style="md-effect-5">Above / From Above</button>
-    <button class="effeckt-positional-modal-button" data-effeckt-positional-modal-type="above" data-effeckt-modal-style="md-effect-2">Above / Slide In (right)</button>
+    <button class="effeckt-positional-modal-button" data-effeckt-positional-modal-position="above" data-effeckt-type="from-below">Above / From Below</button>
+    <button class="effeckt-positional-modal-button" data-effeckt-positional-modal-position="above" data-effeckt-type="from-above">Above / From Above</button>
+    <button class="effeckt-positional-modal-button" data-effeckt-positional-modal-position="above" data-effeckt-type="slide-in-right">Above / Slide In (right)</button>
 
-    <button class="effeckt-positional-modal-button" data-effeckt-positional-modal-type="below" data-effeckt-modal-style="md-effect-1">Below / From Below</button>
+    <button class="effeckt-positional-modal-button" data-effeckt-positional-modal-position="below" data-effeckt-type="from-below">Below / From Below</button>
   </div>
 
 </div>

--- a/js/modules/positional-modals.js
+++ b/js/modules/positional-modals.js
@@ -30,8 +30,8 @@ var EffecktPositionalModals = {
   openModal: function($el) {
 
     var self = this,
-        style = $el.data('effeckt-modal-style'),
-        position = $el.data('effeckt-positional-modal-type'),
+        style = $el.data('effeckt-type'),
+        position = $el.data('effeckt-positional-modal-position'),
         buttonPosition = $el.offset(),
         buttonSize = {
           'width': $el.outerWidth(),

--- a/src/templates/pages/positional-modals.hbs
+++ b/src/templates/pages/positional-modals.hbs
@@ -8,11 +8,11 @@
   </header>
 
   <div class="button-group">
-    <button class="effeckt-positional-modal-button" data-effeckt-positional-modal-type="above" data-effeckt-modal-style="md-effect-1">Above / From Below</button>
-    <button class="effeckt-positional-modal-button" data-effeckt-positional-modal-type="above" data-effeckt-modal-style="md-effect-5">Above / From Above</button>
-    <button class="effeckt-positional-modal-button" data-effeckt-positional-modal-type="above" data-effeckt-modal-style="md-effect-2">Above / Slide In (right)</button>
+    <button class="effeckt-positional-modal-button" data-effeckt-positional-modal-position="above" data-effeckt-type="from-below">Above / From Below</button>
+    <button class="effeckt-positional-modal-button" data-effeckt-positional-modal-position="above" data-effeckt-type="from-above">Above / From Above</button>
+    <button class="effeckt-positional-modal-button" data-effeckt-positional-modal-position="above" data-effeckt-type="slide-in-right">Above / Slide In (right)</button>
 
-    <button class="effeckt-positional-modal-button" data-effeckt-positional-modal-type="below" data-effeckt-modal-style="md-effect-1">Below / From Below</button>
+    <button class="effeckt-positional-modal-button" data-effeckt-positional-modal-position="below" data-effeckt-type="from-below">Below / From Below</button>
   </div>
 
 </div>


### PR DESCRIPTION
This fix a problem where it was using the old classes names provoking the positional modal to not work.
