### PR TITLE
Prevent out of position tooltip

### DIFF
--- a/css/effeckt.autoprefixed.css
+++ b/css/effeckt.autoprefixed.css
@@ -6442,6 +6442,7 @@ Example markup:
 
 .effeckt-tooltip[data-effeckt-tooltip-text] {
   position: relative;
+  display: inline-block;
 }
 
 .effeckt-tooltip[data-effeckt-tooltip-text]::before,

--- a/css/effeckt.css
+++ b/css/effeckt.css
@@ -2250,7 +2250,8 @@ Example markup:
   animation-delay: 1000s; }
 
 .effeckt-tooltip[data-effeckt-tooltip-text] {
-  position: relative; }
+  position: relative;
+  display: inline-block; }
   .effeckt-tooltip[data-effeckt-tooltip-text]::before, .effeckt-tooltip[data-effeckt-tooltip-text]::after {
     opacity: 0;
     transition: 0.2s; }

--- a/css/modules/tooltips.autoprefixed.css
+++ b/css/modules/tooltips.autoprefixed.css
@@ -1,5 +1,6 @@
 .effeckt-tooltip[data-effeckt-tooltip-text] {
   position: relative;
+  display: inline-block;
 }
 
 .effeckt-tooltip[data-effeckt-tooltip-text]::before,

--- a/css/modules/tooltips.css
+++ b/css/modules/tooltips.css
@@ -1,5 +1,6 @@
 .effeckt-tooltip[data-effeckt-tooltip-text] {
-  position: relative; }
+  position: relative;
+  display: inline-block; }
   .effeckt-tooltip[data-effeckt-tooltip-text]::before, .effeckt-tooltip[data-effeckt-tooltip-text]::after {
     opacity: 0;
     transition: 0.2s; }

--- a/dist/assets/css/effeckt.autoprefixed.css
+++ b/dist/assets/css/effeckt.autoprefixed.css
@@ -6442,6 +6442,7 @@ Example markup:
 
 .effeckt-tooltip[data-effeckt-tooltip-text] {
   position: relative;
+  display: inline-block;
 }
 
 .effeckt-tooltip[data-effeckt-tooltip-text]::before,

--- a/dist/assets/css/effeckt.css
+++ b/dist/assets/css/effeckt.css
@@ -2250,7 +2250,8 @@ Example markup:
   animation-delay: 1000s; }
 
 .effeckt-tooltip[data-effeckt-tooltip-text] {
-  position: relative; }
+  position: relative;
+  display: inline-block; }
   .effeckt-tooltip[data-effeckt-tooltip-text]::before, .effeckt-tooltip[data-effeckt-tooltip-text]::after {
     opacity: 0;
     transition: 0.2s; }

--- a/dist/assets/css/modules/tooltips.autoprefixed.css
+++ b/dist/assets/css/modules/tooltips.autoprefixed.css
@@ -1,5 +1,6 @@
 .effeckt-tooltip[data-effeckt-tooltip-text] {
   position: relative;
+  display: inline-block;
 }
 
 .effeckt-tooltip[data-effeckt-tooltip-text]::before,

--- a/dist/assets/css/modules/tooltips.css
+++ b/dist/assets/css/modules/tooltips.css
@@ -1,5 +1,6 @@
 .effeckt-tooltip[data-effeckt-tooltip-text] {
-  position: relative; }
+  position: relative;
+  display: inline-block; }
   .effeckt-tooltip[data-effeckt-tooltip-text]::before, .effeckt-tooltip[data-effeckt-tooltip-text]::after {
     opacity: 0;
     transition: 0.2s; }

--- a/scss/modules/tooltips.scss
+++ b/scss/modules/tooltips.scss
@@ -6,6 +6,9 @@
 // Basic .effeck-tooltip
 .effeckt-tooltip[data-effeckt-tooltip-text] {
   position: relative;
+  // make tooltip text to be always on the same line
+  // this prevent out of position tooltip
+  display: inline-block;
 
   &::before, &::after {
     opacity: 0;


### PR DESCRIPTION
This avoid tooltip to be out of position when the text that triggers it is on separate lines, this make sure the text is on the same line.
