### PR TITLE
Fix Revolving Door Caption on Chrome 24 Ubuntu 12.04 and Chrome 29 OSX 10.8.4

### DIFF
--- a/css/effeckt.autoprefixed.css
+++ b/css/effeckt.autoprefixed.css
@@ -879,10 +879,6 @@ Example markup:
 
 .effeckt-caption[data-effeckt-type="revolving-door"] {
   overflow: visible;
-  -webkit-perspective: 1300px;
-  -ms-perspective: 1300px;
-  -o-perspective: 1300px;
-  perspective: 1300px;
 }
 
 .effeckt-caption[data-effeckt-type="revolving-door"] figcaption {
@@ -890,10 +886,10 @@ Example markup:
   left: 0;
   width: 100%;
   height: 100%;
-  -webkit-transform: rotateY(180deg);
-  -ms-transform: rotateY(180deg);
-  -o-transform: rotateY(180deg);
-  transform: rotateY(180deg);
+  -webkit-transform: perspective(1300px) rotateY(180deg);
+  -ms-transform: perspective(1300px) rotateY(180deg);
+  -o-transform: perspective(1300px) rotateY(180deg);
+  transform: perspective(1300px) rotateY(180deg);
   -webkit-backface-visibility: hidden;
   -ms-backface-visibility: hidden;
   -o-backface-visibility: hidden;
@@ -901,25 +897,29 @@ Example markup:
 }
 
 .effeckt-caption[data-effeckt-type="revolving-door"] img {
-  -webkit-transition: 0.5s;
-  -o-transition: 0.5s;
-  transition: 0.5s;
+  -webkit-transform: perspective(1300px);
+  -ms-transform: perspective(1300px);
+  -o-transform: perspective(1300px);
+  transform: perspective(1300px);
+  -webkit-transition: 500ms;
+  -o-transition: 500ms;
+  transition: 500ms;
 }
 
 .effeckt-caption[data-effeckt-type="revolving-door"]:hover figcaption,
 .effeckt-caption[data-effeckt-type="revolving-door"]:active figcaption {
-  -webkit-transform: rotateY(360deg);
-  -ms-transform: rotateY(360deg);
-  -o-transform: rotateY(360deg);
-  transform: rotateY(360deg);
+  -webkit-transform: perspective(1300px) rotateY(0deg);
+  -ms-transform: perspective(1300px) rotateY(0deg);
+  -o-transform: perspective(1300px) rotateY(0deg);
+  transform: perspective(1300px) rotateY(0deg);
 }
 
 .effeckt-caption[data-effeckt-type="revolving-door"]:hover img,
 .effeckt-caption[data-effeckt-type="revolving-door"]:active img {
-  -webkit-transform: rotateY(180deg);
-  -ms-transform: rotateY(180deg);
-  -o-transform: rotateY(180deg);
-  transform: rotateY(180deg);
+  -webkit-transform: perspective(1300px) rotateY(-180deg);
+  -ms-transform: perspective(1300px) rotateY(-180deg);
+  -o-transform: perspective(1300px) rotateY(-180deg);
+  transform: perspective(1300px) rotateY(-180deg);
 }
 
 .effeckt-caption[data-effeckt-type="offset"] {

--- a/css/effeckt.css
+++ b/css/effeckt.css
@@ -484,21 +484,21 @@ Example markup:
   .effeckt-caption[data-effeckt-type="quarter-zoom"]:hover img, .effeckt-caption[data-effeckt-type="quarter-zoom"]:active img {
     transform: scale(1.1); }
   .effeckt-caption[data-effeckt-type="revolving-door"] {
-    overflow: visible;
-    perspective: 1300px; }
+    overflow: visible; }
     .effeckt-caption[data-effeckt-type="revolving-door"] figcaption {
       top: 0;
       left: 0;
       width: 100%;
       height: 100%;
-      transform: rotateY(180deg);
+      transform: perspective(1300px) rotateY(180deg);
       backface-visibility: hidden; }
     .effeckt-caption[data-effeckt-type="revolving-door"] img {
-      transition: 0.5s; }
+      transform: perspective(1300px);
+      transition: 500ms; }
     .effeckt-caption[data-effeckt-type="revolving-door"]:hover figcaption, .effeckt-caption[data-effeckt-type="revolving-door"]:active figcaption {
-      transform: rotateY(360deg); }
+      transform: perspective(1300px) rotateY(0deg); }
     .effeckt-caption[data-effeckt-type="revolving-door"]:hover img, .effeckt-caption[data-effeckt-type="revolving-door"]:active img {
-      transform: rotateY(180deg); }
+      transform: perspective(1300px) rotateY(-180deg); }
   .effeckt-caption[data-effeckt-type="offset"] {
     overflow: visible; }
     .effeckt-caption[data-effeckt-type="offset"] figcaption {

--- a/css/modules/captions.autoprefixed.css
+++ b/css/modules/captions.autoprefixed.css
@@ -287,10 +287,6 @@
 
 .effeckt-caption[data-effeckt-type="revolving-door"] {
   overflow: visible;
-  -webkit-perspective: 1300px;
-  -ms-perspective: 1300px;
-  -o-perspective: 1300px;
-  perspective: 1300px;
 }
 
 .effeckt-caption[data-effeckt-type="revolving-door"] figcaption {
@@ -298,10 +294,10 @@
   left: 0;
   width: 100%;
   height: 100%;
-  -webkit-transform: rotateY(180deg);
-  -ms-transform: rotateY(180deg);
-  -o-transform: rotateY(180deg);
-  transform: rotateY(180deg);
+  -webkit-transform: perspective(1300px) rotateY(180deg);
+  -ms-transform: perspective(1300px) rotateY(180deg);
+  -o-transform: perspective(1300px) rotateY(180deg);
+  transform: perspective(1300px) rotateY(180deg);
   -webkit-backface-visibility: hidden;
   -ms-backface-visibility: hidden;
   -o-backface-visibility: hidden;
@@ -309,25 +305,29 @@
 }
 
 .effeckt-caption[data-effeckt-type="revolving-door"] img {
-  -webkit-transition: 0.5s;
-  -o-transition: 0.5s;
-  transition: 0.5s;
+  -webkit-transform: perspective(1300px);
+  -ms-transform: perspective(1300px);
+  -o-transform: perspective(1300px);
+  transform: perspective(1300px);
+  -webkit-transition: 500ms;
+  -o-transition: 500ms;
+  transition: 500ms;
 }
 
 .effeckt-caption[data-effeckt-type="revolving-door"]:hover figcaption,
 .effeckt-caption[data-effeckt-type="revolving-door"]:active figcaption {
-  -webkit-transform: rotateY(360deg);
-  -ms-transform: rotateY(360deg);
-  -o-transform: rotateY(360deg);
-  transform: rotateY(360deg);
+  -webkit-transform: perspective(1300px) rotateY(0deg);
+  -ms-transform: perspective(1300px) rotateY(0deg);
+  -o-transform: perspective(1300px) rotateY(0deg);
+  transform: perspective(1300px) rotateY(0deg);
 }
 
 .effeckt-caption[data-effeckt-type="revolving-door"]:hover img,
 .effeckt-caption[data-effeckt-type="revolving-door"]:active img {
-  -webkit-transform: rotateY(180deg);
-  -ms-transform: rotateY(180deg);
-  -o-transform: rotateY(180deg);
-  transform: rotateY(180deg);
+  -webkit-transform: perspective(1300px) rotateY(-180deg);
+  -ms-transform: perspective(1300px) rotateY(-180deg);
+  -o-transform: perspective(1300px) rotateY(-180deg);
+  transform: perspective(1300px) rotateY(-180deg);
 }
 
 .effeckt-caption[data-effeckt-type="offset"] {

--- a/css/modules/captions.css
+++ b/css/modules/captions.css
@@ -122,21 +122,21 @@
   .effeckt-caption[data-effeckt-type="quarter-zoom"]:hover img, .effeckt-caption[data-effeckt-type="quarter-zoom"]:active img {
     transform: scale(1.1); }
   .effeckt-caption[data-effeckt-type="revolving-door"] {
-    overflow: visible;
-    perspective: 1300px; }
+    overflow: visible; }
     .effeckt-caption[data-effeckt-type="revolving-door"] figcaption {
       top: 0;
       left: 0;
       width: 100%;
       height: 100%;
-      transform: rotateY(180deg);
+      transform: perspective(1300px) rotateY(180deg);
       backface-visibility: hidden; }
     .effeckt-caption[data-effeckt-type="revolving-door"] img {
-      transition: 0.5s; }
+      transform: perspective(1300px);
+      transition: 500ms; }
     .effeckt-caption[data-effeckt-type="revolving-door"]:hover figcaption, .effeckt-caption[data-effeckt-type="revolving-door"]:active figcaption {
-      transform: rotateY(360deg); }
+      transform: perspective(1300px) rotateY(0deg); }
     .effeckt-caption[data-effeckt-type="revolving-door"]:hover img, .effeckt-caption[data-effeckt-type="revolving-door"]:active img {
-      transform: rotateY(180deg); }
+      transform: perspective(1300px) rotateY(-180deg); }
   .effeckt-caption[data-effeckt-type="offset"] {
     overflow: visible; }
     .effeckt-caption[data-effeckt-type="offset"] figcaption {

--- a/dist/assets/css/effeckt.autoprefixed.css
+++ b/dist/assets/css/effeckt.autoprefixed.css
@@ -879,10 +879,6 @@ Example markup:
 
 .effeckt-caption[data-effeckt-type="revolving-door"] {
   overflow: visible;
-  -webkit-perspective: 1300px;
-  -ms-perspective: 1300px;
-  -o-perspective: 1300px;
-  perspective: 1300px;
 }
 
 .effeckt-caption[data-effeckt-type="revolving-door"] figcaption {
@@ -890,10 +886,10 @@ Example markup:
   left: 0;
   width: 100%;
   height: 100%;
-  -webkit-transform: rotateY(180deg);
-  -ms-transform: rotateY(180deg);
-  -o-transform: rotateY(180deg);
-  transform: rotateY(180deg);
+  -webkit-transform: perspective(1300px) rotateY(180deg);
+  -ms-transform: perspective(1300px) rotateY(180deg);
+  -o-transform: perspective(1300px) rotateY(180deg);
+  transform: perspective(1300px) rotateY(180deg);
   -webkit-backface-visibility: hidden;
   -ms-backface-visibility: hidden;
   -o-backface-visibility: hidden;
@@ -901,25 +897,29 @@ Example markup:
 }
 
 .effeckt-caption[data-effeckt-type="revolving-door"] img {
-  -webkit-transition: 0.5s;
-  -o-transition: 0.5s;
-  transition: 0.5s;
+  -webkit-transform: perspective(1300px);
+  -ms-transform: perspective(1300px);
+  -o-transform: perspective(1300px);
+  transform: perspective(1300px);
+  -webkit-transition: 500ms;
+  -o-transition: 500ms;
+  transition: 500ms;
 }
 
 .effeckt-caption[data-effeckt-type="revolving-door"]:hover figcaption,
 .effeckt-caption[data-effeckt-type="revolving-door"]:active figcaption {
-  -webkit-transform: rotateY(360deg);
-  -ms-transform: rotateY(360deg);
-  -o-transform: rotateY(360deg);
-  transform: rotateY(360deg);
+  -webkit-transform: perspective(1300px) rotateY(0deg);
+  -ms-transform: perspective(1300px) rotateY(0deg);
+  -o-transform: perspective(1300px) rotateY(0deg);
+  transform: perspective(1300px) rotateY(0deg);
 }
 
 .effeckt-caption[data-effeckt-type="revolving-door"]:hover img,
 .effeckt-caption[data-effeckt-type="revolving-door"]:active img {
-  -webkit-transform: rotateY(180deg);
-  -ms-transform: rotateY(180deg);
-  -o-transform: rotateY(180deg);
-  transform: rotateY(180deg);
+  -webkit-transform: perspective(1300px) rotateY(-180deg);
+  -ms-transform: perspective(1300px) rotateY(-180deg);
+  -o-transform: perspective(1300px) rotateY(-180deg);
+  transform: perspective(1300px) rotateY(-180deg);
 }
 
 .effeckt-caption[data-effeckt-type="offset"] {

--- a/dist/assets/css/effeckt.css
+++ b/dist/assets/css/effeckt.css
@@ -484,21 +484,21 @@ Example markup:
   .effeckt-caption[data-effeckt-type="quarter-zoom"]:hover img, .effeckt-caption[data-effeckt-type="quarter-zoom"]:active img {
     transform: scale(1.1); }
   .effeckt-caption[data-effeckt-type="revolving-door"] {
-    overflow: visible;
-    perspective: 1300px; }
+    overflow: visible; }
     .effeckt-caption[data-effeckt-type="revolving-door"] figcaption {
       top: 0;
       left: 0;
       width: 100%;
       height: 100%;
-      transform: rotateY(180deg);
+      transform: perspective(1300px) rotateY(180deg);
       backface-visibility: hidden; }
     .effeckt-caption[data-effeckt-type="revolving-door"] img {
-      transition: 0.5s; }
+      transform: perspective(1300px);
+      transition: 500ms; }
     .effeckt-caption[data-effeckt-type="revolving-door"]:hover figcaption, .effeckt-caption[data-effeckt-type="revolving-door"]:active figcaption {
-      transform: rotateY(360deg); }
+      transform: perspective(1300px) rotateY(0deg); }
     .effeckt-caption[data-effeckt-type="revolving-door"]:hover img, .effeckt-caption[data-effeckt-type="revolving-door"]:active img {
-      transform: rotateY(180deg); }
+      transform: perspective(1300px) rotateY(-180deg); }
   .effeckt-caption[data-effeckt-type="offset"] {
     overflow: visible; }
     .effeckt-caption[data-effeckt-type="offset"] figcaption {

--- a/dist/assets/css/modules/captions.autoprefixed.css
+++ b/dist/assets/css/modules/captions.autoprefixed.css
@@ -287,10 +287,6 @@
 
 .effeckt-caption[data-effeckt-type="revolving-door"] {
   overflow: visible;
-  -webkit-perspective: 1300px;
-  -ms-perspective: 1300px;
-  -o-perspective: 1300px;
-  perspective: 1300px;
 }
 
 .effeckt-caption[data-effeckt-type="revolving-door"] figcaption {
@@ -298,10 +294,10 @@
   left: 0;
   width: 100%;
   height: 100%;
-  -webkit-transform: rotateY(180deg);
-  -ms-transform: rotateY(180deg);
-  -o-transform: rotateY(180deg);
-  transform: rotateY(180deg);
+  -webkit-transform: perspective(1300px) rotateY(180deg);
+  -ms-transform: perspective(1300px) rotateY(180deg);
+  -o-transform: perspective(1300px) rotateY(180deg);
+  transform: perspective(1300px) rotateY(180deg);
   -webkit-backface-visibility: hidden;
   -ms-backface-visibility: hidden;
   -o-backface-visibility: hidden;
@@ -309,25 +305,29 @@
 }
 
 .effeckt-caption[data-effeckt-type="revolving-door"] img {
-  -webkit-transition: 0.5s;
-  -o-transition: 0.5s;
-  transition: 0.5s;
+  -webkit-transform: perspective(1300px);
+  -ms-transform: perspective(1300px);
+  -o-transform: perspective(1300px);
+  transform: perspective(1300px);
+  -webkit-transition: 500ms;
+  -o-transition: 500ms;
+  transition: 500ms;
 }
 
 .effeckt-caption[data-effeckt-type="revolving-door"]:hover figcaption,
 .effeckt-caption[data-effeckt-type="revolving-door"]:active figcaption {
-  -webkit-transform: rotateY(360deg);
-  -ms-transform: rotateY(360deg);
-  -o-transform: rotateY(360deg);
-  transform: rotateY(360deg);
+  -webkit-transform: perspective(1300px) rotateY(0deg);
+  -ms-transform: perspective(1300px) rotateY(0deg);
+  -o-transform: perspective(1300px) rotateY(0deg);
+  transform: perspective(1300px) rotateY(0deg);
 }
 
 .effeckt-caption[data-effeckt-type="revolving-door"]:hover img,
 .effeckt-caption[data-effeckt-type="revolving-door"]:active img {
-  -webkit-transform: rotateY(180deg);
-  -ms-transform: rotateY(180deg);
-  -o-transform: rotateY(180deg);
-  transform: rotateY(180deg);
+  -webkit-transform: perspective(1300px) rotateY(-180deg);
+  -ms-transform: perspective(1300px) rotateY(-180deg);
+  -o-transform: perspective(1300px) rotateY(-180deg);
+  transform: perspective(1300px) rotateY(-180deg);
 }
 
 .effeckt-caption[data-effeckt-type="offset"] {

--- a/dist/assets/css/modules/captions.css
+++ b/dist/assets/css/modules/captions.css
@@ -122,21 +122,21 @@
   .effeckt-caption[data-effeckt-type="quarter-zoom"]:hover img, .effeckt-caption[data-effeckt-type="quarter-zoom"]:active img {
     transform: scale(1.1); }
   .effeckt-caption[data-effeckt-type="revolving-door"] {
-    overflow: visible;
-    perspective: 1300px; }
+    overflow: visible; }
     .effeckt-caption[data-effeckt-type="revolving-door"] figcaption {
       top: 0;
       left: 0;
       width: 100%;
       height: 100%;
-      transform: rotateY(180deg);
+      transform: perspective(1300px) rotateY(180deg);
       backface-visibility: hidden; }
     .effeckt-caption[data-effeckt-type="revolving-door"] img {
-      transition: 0.5s; }
+      transform: perspective(1300px);
+      transition: 500ms; }
     .effeckt-caption[data-effeckt-type="revolving-door"]:hover figcaption, .effeckt-caption[data-effeckt-type="revolving-door"]:active figcaption {
-      transform: rotateY(360deg); }
+      transform: perspective(1300px) rotateY(0deg); }
     .effeckt-caption[data-effeckt-type="revolving-door"]:hover img, .effeckt-caption[data-effeckt-type="revolving-door"]:active img {
-      transform: rotateY(180deg); }
+      transform: perspective(1300px) rotateY(-180deg); }
   .effeckt-caption[data-effeckt-type="offset"] {
     overflow: visible; }
     .effeckt-caption[data-effeckt-type="offset"] figcaption {

--- a/scss/modules/captions.scss
+++ b/scss/modules/captions.scss
@@ -230,24 +230,24 @@
   // BUG: Super flickery in Safari 5.1.7 on Windows 7
   &[data-effeckt-type="revolving-door"] {
     overflow: visible;
-    perspective: 1300px;
     figcaption {
       top: 0;
       left: 0;
       width: 100%;
       height: 100%;
-      transform: rotateY(180deg);
+      transform: perspective(1300px) rotateY(180deg);
       backface-visibility: hidden;
     }
     img {
-      transition: 0.5s;
+      transform: perspective(1300px);
+      transition: $effeckt-caption-transition-duration;
     }
     &:hover, &:active {
       figcaption {
-       transform: rotateY(360deg);
+        transform: perspective(1300px) rotateY(0deg);
       }
       img {
-        transform: rotateY(180deg);
+        transform: perspective(1300px) rotateY(-180deg);
       }
     }
   }


### PR DESCRIPTION
The Revolving Door Caption was only being triggered on hover over the left-half of the element in Chrome (on Ubuntu and OSX) see video: http://www.youtube.com/watch?v=z5LEkIe00x8

Moving the transform perspective to the child elements seems to have fixed this, and, is seemingly more performant. I rolled over the transition a few times and recorded frames in Chrome Dev tools

old: http://cl.ly/image/183v2x280A0m
new: http://cl.ly/image/0c0k373s3P2N

Summary of commit:
- Move perspective from parent element to child elements
- Change rotation direction for straight-forward approach
- Modify transition to use $effeckt-caption-transition-duration variable rather than magic number
