### PR TITLE
Added grunt-build-control to Effeckt.css

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -67,7 +67,7 @@ module.exports = function(grunt) {
       server: {
         options: {
           port: 8000,
-          base: './'
+          base: 'dist/'
         }
       }
     },
@@ -107,6 +107,20 @@ module.exports = function(grunt) {
           { expand: true, cwd: './js', src: ['./**/*.*'], dest: 'dist/assets/js' }
         ]
       }
+    },
+    buildcontrol: {
+      options: {
+        dir: 'dist',
+        commit: true,
+        push: true,
+        message: 'Built %sourceName% from commit %sourceCommit% on branch %sourceBranch%'
+      },
+      pages: {
+        options: {
+          remote: 'https://github.com/h5bp/Effeckt.css.git',
+          branch: 'gh-pages'
+        }
+      },
     }
 
   });
@@ -122,6 +136,7 @@ module.exports = function(grunt) {
   grunt.registerTask('demo', ['copy:demo', 'assemble:demo']);
   grunt.registerTask('deploy', ['gh-pages']);
 
+  grunt.registerTask('deploy', ['default', 'buildcontrol']);
   grunt.loadNpmTasks('assemble');
   require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
 };

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "grunt-contrib-copy": "~0.4.1",
     "assemble": "~0.4.0",
     "grunt-gh-pages": "~0.6.0",
-    "grunt-sass": "~0.6.0"
+    "grunt-sass": "~0.6.0",
+    "grunt-build-control": "~0.1.1"
   },
   "engines": {
     "node": ">=0.10"


### PR DESCRIPTION
@benschwarz [mentioned](https://twitter.com/benschwarz/status/397221857830510592) he was interested in putting grunt-build-control into Effeckt.css, and since I'd just done this for my personal blog only an hour ago, I made this pull request while it was still fresh in my memory.

We have one hurdle.

There'll need to be a new `main` branch, as this commits to `gh-pages`.
