### PR TITLE
Jank Fix iPad2 iOS6,7: For page transitions module.

### DIFF
--- a/css/effeckt.css
+++ b/css/effeckt.css
@@ -6046,6 +6046,7 @@ Example markup:
   left: 0;
   width: 100%;
   height: 100%;
+  -webkit-overflow-scrolling: touch;
   overflow-x: hidden;
   visibility: hidden;
   z-index: 0;

--- a/css/modules/page-transitions.css
+++ b/css/modules/page-transitions.css
@@ -4,6 +4,7 @@
   left: 0;
   width: 100%;
   height: 100%;
+  -webkit-overflow-scrolling: touch;
   overflow-x: hidden;
   visibility: hidden;
   z-index: 0;

--- a/dist/assets/css/effeckt.css
+++ b/dist/assets/css/effeckt.css
@@ -6046,6 +6046,7 @@ Example markup:
   left: 0;
   width: 100%;
   height: 100%;
+  -webkit-overflow-scrolling: touch;
   overflow-x: hidden;
   visibility: hidden;
   z-index: 0;

--- a/dist/assets/css/modules/page-transitions.css
+++ b/dist/assets/css/modules/page-transitions.css
@@ -4,6 +4,7 @@
   left: 0;
   width: 100%;
   height: 100%;
+  -webkit-overflow-scrolling: touch;
   overflow-x: hidden;
   visibility: hidden;
   z-index: 0;

--- a/scss/modules/page-transitions.scss
+++ b/scss/modules/page-transitions.scss
@@ -13,6 +13,7 @@
   left:0;
   width: 100%;
   height: 100%;
+  -webkit-overflow-scrolling: touch;
   overflow-x: hidden;
   visibility: hidden;
   z-index:0;


### PR DESCRIPTION
-webkit-overflow-scrolling: touch;
P.S. This is manually prefixed because the auto-prefixer cannot prefix this.

reference:
## https://github.com/h5bp/Effeckt.css/pull/227

(I edited .scss file only)
(.css file changes are generated by grunt.)
