### PR TITLE
ignore dist and .grunt directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
+.grunt
 /.sass-cache/
+dist
 node_modules/
 /tmp/
 .DS_Store


### PR DESCRIPTION
added two lines on `.gitignore` to ignore `dist` and `.grunt` directory on master branch.
