### PR TITLE
Correcting link to demo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ Originally started at [h5bp/lazyweb-requests#122](https://github.com/h5bp/lazywe
 Head here → [http://github.com/h5bp/Effeckt.css/issues](https://github.com/h5bp/Effeckt.css/issues)
 
 ### Work In Progress Demo Page
-Head here → [http://h5bp.github.io/Effeckt.css/dist/](http://h5bp.github.io/Effeckt.css/dist/)
+Head here → [http://h5bp.github.io/Effeckt.css/](http://h5bp.github.io/Effeckt.css/)
 
 ### ✭ Contributing & Pull Requests
 If you'd like to contribute to the [Effeckt.css](https://github.com/h5bp/Effeckt.css) project (btw you're awesome for doing so) then we suggest you do the following…


### PR DESCRIPTION
The link to the demo in the readme was pointing to the dist folder, a 404.
