### PR TITLE
Update license year

### DIFF
--- a/License.md
+++ b/License.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2013 Contributors to https://github.com/h5bp/Effeckt.css/
+Copyright (c) 2013-2014 Contributors to https://github.com/h5bp/Effeckt.css/
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Fix outdated copyright year (updated to 2014).
The copyright year was out of date. Copyright notices must reflect the current year, so this commit updates the listed year to 2014.

See http://www.copyright.gov/circs/circ01.pdf for more info.
