### PR TITLE
Remove outline for iOS/Android style checkbox's

### DIFF
--- a/scss/modules/form-elements.scss
+++ b/scss/modules/form-elements.scss
@@ -25,6 +25,7 @@
   position: relative;
   margin: 0px;
   width: 52px;
+  outline: 0;
   transition: $effeckt-form-element-ckradio-ios7transition;
   transform: scale(1); // Adjust size here
   background: $effeckt-form-element-ckradio-ios7bg-off;
@@ -70,6 +71,7 @@
   position: relative;
   margin: 0px;
   width: 72px;
+  outline: 0;
   -webkit-transition: all 0.3s ease-out;
   -o-transition: all 0.3s ease-out;
   transition: all 0.3s ease-out;


### PR DESCRIPTION
Remove the annoying default outline webkit places around this element on focus. added to each type instead of creating a &:focus selector as the overall css footprint would be smaller.
