### PR TITLE
Now listens for both touch and click events.

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -4,11 +4,8 @@
     // Is Modernizr defined on the global scope
     Modernizr = typeof Modernizr !== "undefined" ? Modernizr : false,
 
-    // whether or not is a touch device
-    isTouchDevice = Modernizr ? Modernizr.touch : !!('ontouchstart' in window || 'onmsgesturechange' in window),
-
-    // Are we expecting a touch or a click?
-    buttonPressedEvent = ( isTouchDevice ) ? 'touchstart' : 'click',
+    // Always expect both kinds of event
+    buttonPressedEvent = 'touchstart click',
 
     // List of all animation/transition properties
     // with its animationEnd/transitionEnd event


### PR DESCRIPTION
No longer requires isTouchdevice variable.

A fix for #289
