### PR TITLE
PR for removing functions which overlap with jQuery

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -40,18 +40,6 @@
     this.transitionAnimationEndEvent = this.animationEndEventName + ' ' + this.transitionEndEventName;
   };
 
-  Effeckt.prototype.getViewportHeight = function() {
-
-    var docElement = document.documentElement,
-      client = docElement['clientHeight'],
-      inner = window['innerHeight'];
-
-    if( client < inner )
-      return inner;
-    else
-      return client;
-  };
-
   // Get all the properties for transition/animation end
   function getTransitionEndEventNames() {
     return _getEndEventNames( transitionEndEventNames );

--- a/js/demo/lazy-loading.js
+++ b/js/demo/lazy-loading.js
@@ -3,7 +3,7 @@
 // because it's change according to the scroll
 var EffecktLazyLoading = {
 
-  init: function() {
+  init: function(window) {
 
     var self = this;
 
@@ -13,7 +13,7 @@ var EffecktLazyLoading = {
     this.wrapper = $('.effeckt-lazy-loading');
     this.needsPerspective = this.wrapper.data('effeckt-needs-perspective')?true:false;
 
-    this.viewportHeight = this.getViewportHeight();
+    this.viewportHeight = $(window).height();
 
     this.elements.each( function( i, el ) {
 
@@ -26,14 +26,15 @@ var EffecktLazyLoading = {
 
   bindUIActions: function() {
 
-    var self = this;
+    var self = this,
+      windowObj = $(window);
 
     $('.effeckt-page-active').on( 'scroll', function(){
       self._onScrollMethod();
     });
 
-    $(window).on( 'resize', function() {
-      self.viewportHeight = self.getViewportHeight();
+    windowObj.on( 'resize', function() {
+      self.viewportHeight = windowObj.height();
     });
 
     $('.effeckt-lazy-loading-options input[type=radio]').on( 'click', function(){
@@ -45,7 +46,7 @@ var EffecktLazyLoading = {
   _scrollPage: function() {
 
     var self = this;
-    
+
     this.didScroll = false;
 
     if ( self.needsPerspective ) {
@@ -74,24 +75,11 @@ var EffecktLazyLoading = {
       scrolled = $('.effeckt-page-active').scrollTop(),
       viewed = scrolled + this.viewportHeight,
       elTop = $(el).offset().top,
-      elBottom = elTop + elHeight,
       // if 0, the element is considered in the viewport as soon as it enters.
       // if 1, the element is considered in the viewport only when it's fully inside
       // value in percentage (1 >= h >= 0)
       h = 0.75;
     return (elTop + (elHeight * h) + scrolled) <= viewed;
-  },
-
-  getViewportHeight: function() {
-
-    var docElement = document.documentElement,
-      client = docElement['clientHeight'],
-      inner = window['innerHeight'];
-
-    if( client < inner )
-      return inner;
-    else
-      return client;
   },
 
   _onScrollMethod : function() {
@@ -105,8 +93,8 @@ var EffecktLazyLoading = {
         self._scrollPage();
       }, 1000 / 60);
     }
-  },
+  }
 
 };
 
-EffecktLazyLoading.init();
+EffecktLazyLoading.init(window);

--- a/js/demo/lazy-loading.js
+++ b/js/demo/lazy-loading.js
@@ -3,7 +3,7 @@
 // because it's change according to the scroll
 var EffecktLazyLoading = {
 
-  init: function(window) {
+  init: function() {
 
     var self = this;
 
@@ -74,6 +74,7 @@ var EffecktLazyLoading = {
       scrolled = $('.effeckt-page-active').scrollTop(),
       viewed = scrolled + this.viewportHeight,
       elTop = $(el).offset().top,
+      elBottom = elTop + elHeight,
       // if 0, the element is considered in the viewport as soon as it enters.
       // if 1, the element is considered in the viewport only when it's fully inside
       // value in percentage (1 >= h >= 0)
@@ -96,4 +97,4 @@ var EffecktLazyLoading = {
 
 };
 
-EffecktLazyLoading.init(window);
+EffecktLazyLoading.init();

--- a/js/demo/lazy-loading.js
+++ b/js/demo/lazy-loading.js
@@ -92,7 +92,7 @@ var EffecktLazyLoading = {
         self._scrollPage();
       }, 1000 / 60);
     }
-  }
+  },
 
 };
 

--- a/js/demo/lazy-loading.js
+++ b/js/demo/lazy-loading.js
@@ -26,15 +26,14 @@ var EffecktLazyLoading = {
 
   bindUIActions: function() {
 
-    var self = this,
-      windowObj = $(window);
+    var self = this;
 
     $('.effeckt-page-active').on( 'scroll', function(){
       self._onScrollMethod();
     });
 
-    windowObj.on( 'resize', function() {
-      self.viewportHeight = windowObj.height();
+    $(window).on( 'resize', function() {
+      self.viewportHeight = $(window).height();
     });
 
     $('.effeckt-lazy-loading-options input[type=radio]').on( 'click', function(){


### PR DESCRIPTION
1. Removed getViewportHeight() and used $(window).height()
2. corrected extra commas

https://github.com/h5bp/Effeckt.css/issues/312