### PR TITLE
Added JSCS & JSHint with Travis CI config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /.sass-cache/
 dist
 node_modules/
+.idea/
 /tmp/
 .DS_Store
 npm-debug.log

--- a/.jscsrc
+++ b/.jscsrc
@@ -2,5 +2,17 @@
   "excludeFiles": ["node_modules/**", "bower_components/**"],
   "validateIndentation": 2,
   "disallowMixedSpacesAndTabs": true,
-  "disallowMultipleSpaces":true
+  "disallowMultipleSpaces":true,
+  "requireSemicolons":true,
+  "requireSpaceAfterObjectKeys": true,
+  "requireSpaceAfterLineComment":true,
+  "disallowTrailingComma":true,
+  "requireMultipleVarDecl":true,
+  "disallowSpaceAfterPrefixUnaryOperators":["++", "--", "+", "-", "~", "!"],
+  "requireLineFeedAtFileEnd":true,
+  "validateParameterSeparator":", ",
+  "requireSpaceAfterObjectKeys":true,
+  "requireSpaceAfterBinaryOperators":["="],
+  "requireSpaceBeforeBinaryOperators":["="],
+  "requireSpacesInsideParentheses":"all"
 }

--- a/.jscsrc
+++ b/.jscsrc
@@ -4,7 +4,6 @@
   "disallowMixedSpacesAndTabs": true,
   "disallowMultipleSpaces":true,
   "requireSemicolons":true,
-  "requireSpaceAfterObjectKeys": true,
   "requireSpaceAfterLineComment":true,
   "disallowTrailingComma":true,
   "requireMultipleVarDecl":true,
@@ -15,7 +14,7 @@
   "requireSpaceBeforeBinaryOperators":["="],
   "requireSpacesInsideParentheses":"all",
   "requireSpacesInsideArrayBrackets": "all",
-  "disallowSpaceAfterBinaryOperators":[","],
+  "disallowSpaceBeforeBinaryOperators":[","],
   "requireSpacesInAnonymousFunctionExpression":{
     "beforeOpeningCurlyBrace": true
   },

--- a/.jscsrc
+++ b/.jscsrc
@@ -33,5 +33,6 @@
   },
   "requireSpacesInNamedFunctionExpression":{
     "beforeOpeningCurlyBrace": true
-  }
+  },
+  "requireDollarBeforejQueryAssignment":true
 }

--- a/.jscsrc
+++ b/.jscsrc
@@ -14,5 +14,24 @@
   "requireSpaceAfterBinaryOperators":["="],
   "requireSpaceBeforeBinaryOperators":["="],
   "requireSpacesInsideParentheses":"all",
-  "requireSpacesInsideArrayBrackets": "all"
+  "requireSpacesInsideArrayBrackets": "all",
+  "disallowSpaceAfterBinaryOperators":[","],
+  "requireSpacesInAnonymousFunctionExpression":{
+    "beforeOpeningCurlyBrace": true
+  },
+  "requireSpacesInCallExpression":true,
+  "requireSpacesInConditionalExpression":true,
+  "requireSpacesInForStatement":true,
+  "requireSpacesInFunctionDeclaration":{
+    "beforeOpeningCurlyBrace": true
+  },
+  "requireSpacesInFunctionExpression":{
+    "beforeOpeningCurlyBrace": true
+  },
+  "requireSpacesInFunction":{
+    "beforeOpeningCurlyBrace": true
+  },
+  "requireSpacesInNamedFunctionExpression":{
+    "beforeOpeningCurlyBrace": true
+  }
 }

--- a/.jscsrc
+++ b/.jscsrc
@@ -1,0 +1,6 @@
+{
+  "excludeFiles": ["node_modules/**", "bower_components/**"],
+  "validateIndentation": 2,
+  "disallowMixedSpacesAndTabs": true,
+  "disallowMultipleSpaces":true
+}

--- a/.jscsrc
+++ b/.jscsrc
@@ -11,8 +11,8 @@
   "disallowSpaceAfterPrefixUnaryOperators":["++", "--", "+", "-", "~", "!"],
   "requireLineFeedAtFileEnd":true,
   "validateParameterSeparator":", ",
-  "requireSpaceAfterObjectKeys":true,
   "requireSpaceAfterBinaryOperators":["="],
   "requireSpaceBeforeBinaryOperators":["="],
-  "requireSpacesInsideParentheses":"all"
+  "requireSpacesInsideParentheses":"all",
+  "requireSpacesInsideArrayBrackets": "all"
 }

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,11 @@
+{
+  "bitwise": true,
+  "curly": true,
+  "eqeqeq": true,
+  "freeze": true,
+  "quotmark": "single",
+  "undef": true,
+  "unused": true,
+  "strict": false,
+  "validthis": false
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+- "0.10"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- "0.10"
+- "0.12.4"
 before_install:
 - npm install -g grunt-cli bower
 - bower install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
 language: node_js
 node_js:
 - "0.10"
+before_install:
+- npm install -g grunt-cli bower
+- bower install
+script: grunt quality

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -200,5 +200,5 @@ module.exports = function(grunt) {
   grunt.registerTask('dev', ['connect', 'watch']);
   grunt.registerTask('demo', ['copy:demo', 'assemble:demo']);
   grunt.registerTask('deploy', ['gh-pages:remote']);
-  grunt.registerTask('quality', ['jshint','jscs']);
+  grunt.registerTask('quality', ['jshint:all','jscs:all']);
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -200,4 +200,5 @@ module.exports = function(grunt) {
   grunt.registerTask('dev', ['connect', 'watch']);
   grunt.registerTask('demo', ['copy:demo', 'assemble:demo']);
   grunt.registerTask('deploy', ['gh-pages:remote']);
+  grunt.registerTask('quality', ['jshint','jscs']);
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,11 +1,11 @@
-module.exports = function(grunt) {
+module.exports = function ( grunt ) {
 
   // Load NPM Tasks
   // https://github.com/shootaroo/jit-grunt
-  require('jit-grunt')(grunt);
+  require ( 'jit-grunt' ) ( grunt );
 
-  grunt.initConfig({
-    pkg: grunt.file.readJSON( 'package.json' ),
+  grunt.initConfig ( {
+    pkg: grunt.file.readJSON ( 'package.json' ),
 
     // Copied from Bootstrap
     banner: '/*!\n' +
@@ -20,23 +20,23 @@ module.exports = function(grunt) {
       main: {
         options: {
           reportUpdated: false, // Report updated dependencies: 'false' | 'true'
-          updateType   : "force" // 'force'|'report'|'prompt'
+          updateType: 'force' // 'force'|'report'|'prompt'
         }
       }
     },
 
     watch: {
       scss: {
-        files: ['scss/**/*.scss'],
+        files: [ 'scss/**/*.scss' ],
         tasks: 'scss'
       },
       html: {
-        files: ['src/**/*.hbs'],
+        files: [ 'src/**/*.hbs' ],
         tasks: 'html'
       },
       js: {
-        files: ['js/**/*.js'],
-        tasks: ['jshint','jscs','js']
+        files: [ 'js/**/*.js' ],
+        tasks: [ 'jshint','jscs','js' ]
       },
       livereload: {
         options: {
@@ -54,15 +54,15 @@ module.exports = function(grunt) {
       build: {
         files : [
           {
-            src : ['**/*.scss', '!**/_*.scss'],
-            cwd : 'scss',
-            dest : 'css',
-            ext : '.css',
-            expand : true
+            src: [ '**/*.scss', '!**/_*.scss' ],
+            cwd: 'scss',
+            dest: 'css',
+            ext: '.css',
+            expand: true
           }
         ],
-        options : {
-          style : 'expanded'
+        options: {
+          style: 'expanded'
         }
       }
     },
@@ -71,14 +71,14 @@ module.exports = function(grunt) {
     autoprefixer: {
       build: {
         options: {
-          browsers: ['last 2 versions', '> 1%']
+          browsers: [ 'last 2 versions', '> 1%' ]
         },
         files: [
           {
-            src : ['**/*.css'],
-            cwd : 'css',
-            dest : 'css',
-            expand : true
+            src: [ '**/*.css' ],
+            cwd: 'css',
+            dest: 'css',
+            expand: true
           }
         ]
       }
@@ -90,7 +90,7 @@ module.exports = function(grunt) {
           port: 9001,
           protocol: 'http',
           hostname: 'localhost',
-          base: './dist/',  // '.' operates from the root of your Gruntfile, otherwise -> 'Users/user-name/www-directory/website-directory'
+          base: './dist/',// '.' operates from the root of your Gruntfile, otherwise -> 'Users/user-name/www-directory/website-directory'
           keepalive: false, // set to false to work side by side w/watch task.
           livereload: true,
           open: true
@@ -104,14 +104,14 @@ module.exports = function(grunt) {
         layout: 'layout.hbs',
         layoutdir: 'src/templates/layouts',
         assets: 'dist/assets',
-        partials: ['src/templates/pages/*.hbs', 'src/templates/parts/*.hbs']
+        partials: [ 'src/templates/pages/*.hbs', 'src/templates/parts/*.hbs' ]
       },
       demo: {
         options: {
-          data: ['src/data/*.{json,yml}']
+          data: [ 'src/data/*.{json,yml}' ]
         },
         files: {
-          'dist/': ['src/templates/pages/*.hbs']
+          'dist/': [ 'src/templates/pages/*.hbs' ]
         }
       }
     },
@@ -119,22 +119,22 @@ module.exports = function(grunt) {
     copy: {
       demo: {
         files: [
-          { expand: true, cwd: './css', src: ['./**/*.*'], dest: 'dist/assets/css' },
-          { expand: true, cwd: './js', src: ['./**/*.*'], dest: 'dist/assets/js' },
-          { expand: true, flatten: true, cwd: './bower_components/jQuery', src:['./dist/*.min.*'], dest: 'dist/assets/js/libs/' },
-          { expand: true, flatten: true, cwd: './bower_components/modernizr', src:['./modernizr.js'], dest: 'dist/assets/js/libs/' }
+          { expand: true, cwd: './css', src: [ './**/*.*' ], dest: 'dist/assets/css' },
+          { expand: true, cwd: './js', src: [ './**/*.*' ], dest: 'dist/assets/js' },
+          { expand: true, flatten: true, cwd: './bower_components/jQuery', src:[ './dist/*.min.*' ], dest: 'dist/assets/js/libs/' },
+          { expand: true, flatten: true, cwd: './bower_components/modernizr', src:[ './modernizr.js' ], dest: 'dist/assets/js/libs/' }
         ]
       },
       css: {
         files: [
-          { expand: true, cwd: './css', src: ['./**/*.*'], dest: 'dist/assets/css' }
+          { expand: true, cwd: './css', src: [ './**/*.*' ], dest: 'dist/assets/css' }
         ]
       },
       js: {
         files: [
-          { expand: true, flatten: true, cwd: './bower_components/jQuery', src: ['./dist/*.min.*'], dest: 'dist/assets/js/libs/' },
-          { expand: true, flatten: true, cwd: './bower_components/modernizr', src: ['./modernizr.js'], dest: 'dist/assets/js/libs/' },
-          { expand: true, cwd: './js', src: ['./**/*.*'], dest: 'dist/assets/js' }
+          { expand: true, flatten: true, cwd: './bower_components/jQuery', src: [ './dist/*.min.*' ], dest: 'dist/assets/js/libs/' },
+          { expand: true, flatten: true, cwd: './bower_components/modernizr', src: [ './modernizr.js' ], dest: 'dist/assets/js/libs/' },
+          { expand: true, cwd: './js', src: [ './**/*.*' ], dest: 'dist/assets/js' }
         ]
       }
     },
@@ -176,29 +176,29 @@ module.exports = function(grunt) {
           base: 'dist',
           repo: 'https://github.com/h5bp/Effeckt.css'
         },
-        src: ['**/*']
+        src: [ '**/*' ]
       }
     },
 
-    jshint:{
-      demo:['js/demo/*.js'],
-      modules:['js/modules/*.js'],
-      all:['js/**/*.js']
+    jshint: {
+      demo:[ 'js/demo/*.js' ],
+      modules:[ 'js/modules/*.js' ],
+      all:[ 'js/**/*.js' ]
     },
-    jscs:{
-      demo:['js/demo/*.js'],
-      modules:['js/modules/*.js'],
-      all:['js/**/*.js']
+    jscs: {
+      demo:[ 'js/demo/*.js' ],
+      modules:[ 'js/modules/*.js' ],
+      all:[ 'js/**/*.js' ]
     }
   });
 
-  grunt.registerTask('update', ['devUpdate']);
-  grunt.registerTask('default', ['sass', 'autoprefixer', 'assemble', 'copy']);
-  grunt.registerTask('scss', ['sass', 'autoprefixer', 'copy:css']);
-  grunt.registerTask('html', ['assemble']);
-  grunt.registerTask('js', ['copy:js', 'concat']);
-  grunt.registerTask('dev', ['connect', 'watch']);
-  grunt.registerTask('demo', ['copy:demo', 'assemble:demo']);
-  grunt.registerTask('deploy', ['gh-pages:remote']);
-  grunt.registerTask('quality', ['jshint:all','jscs:all']);
+  grunt.registerTask( 'update', [ 'devUpdate' ] );
+  grunt.registerTask( 'default', [ 'sass', 'autoprefixer', 'assemble', 'copy' ] );
+  grunt.registerTask( 'scss', [ 'sass', 'autoprefixer', 'copy:css' ] );
+  grunt.registerTask( 'html', [ 'assemble' ] );
+  grunt.registerTask( 'js', [ 'copy:js', 'concat' ] );
+  grunt.registerTask( 'dev', [ 'connect', 'watch' ] );
+  grunt.registerTask( 'demo', [ 'copy:demo', 'assemble:demo' ] );
+  grunt.registerTask( 'deploy', [ 'gh-pages:remote' ] );
+  grunt.registerTask( 'quality', [ 'jshint:all','jscs:all' ] );
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -36,7 +36,7 @@ module.exports = function(grunt) {
       },
       js: {
         files: ['js/**/*.js'],
-        tasks: 'js'
+        tasks: ['jshint','jscs','js']
       },
       livereload: {
         options: {
@@ -178,8 +178,18 @@ module.exports = function(grunt) {
         },
         src: ['**/*']
       }
-    }
+    },
 
+    jshint:{
+      demo:['js/demo/*.js'],
+      modules:['js/modules/*.js'],
+      all:['js/**/*.js']
+    },
+    jscs:{
+      demo:['js/demo/*.js'],
+      modules:['js/modules/*.js'],
+      all:['js/**/*.js']
+    }
   });
 
   grunt.registerTask('update', ['devUpdate']);

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "grunt-dev-update": "^0.9.0",
     "grunt-gh-pages": "^0.9.1",
     "grunt-sass": "^0.14.2",
-    "jit-grunt": "^0.8.0"
+    "jit-grunt": "^0.8.0",
+    "jscs": "^1.13.1"
   },
   "engines": {
     "node": ">=0.10"

--- a/package.json
+++ b/package.json
@@ -9,13 +9,15 @@
     "grunt-contrib-concat": "^0.5.0",
     "grunt-contrib-connect": "^0.8.0",
     "grunt-contrib-copy": "^0.6.0",
+    "grunt-contrib-jshint": "^0.11.2",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-dev-update": "^0.9.0",
     "grunt-gh-pages": "^0.9.1",
     "grunt-jscs": "^1.8.0",
     "grunt-sass": "^0.14.2",
     "jit-grunt": "^0.8.0",
-    "jscs": "^1.13.1"
+    "jscs": "^1.13.1",
+    "jshint": "^2.8.0"
   },
   "engines": {
     "node": ">=0.10"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "grunt-contrib-watch": "^0.6.1",
     "grunt-dev-update": "^0.9.0",
     "grunt-gh-pages": "^0.9.1",
+    "grunt-jscs": "^1.8.0",
     "grunt-sass": "^0.14.2",
     "jit-grunt": "^0.8.0",
     "jscs": "^1.13.1"

--- a/package.json
+++ b/package.json
@@ -15,11 +15,9 @@
     "grunt-gh-pages": "^0.9.1",
     "grunt-jscs": "^1.8.0",
     "grunt-sass": "^0.14.2",
-    "jit-grunt": "^0.8.0",
-    "jscs": "^1.13.1",
-    "jshint": "^2.8.0"
+    "jit-grunt": "^0.8.0"
   },
   "engines": {
-    "node": ">=0.10"
+    "node": ">=0.12.4"
   }
 }


### PR DESCRIPTION
This PR fixes https://github.com/h5bp/Effeckt.css/issues/314
- **.jshintrc**
  - [x] Put brakes { after rule declarations/function name/while/for/etc. `curly:true`
- **.jscsrc (Each completed task here has the corresponding jshint rule listed in code blocks)**
  - [x] Use two space indent `"validateIndentation": 2`
  - [x] Put spaces between rule declarations/function name/while/for/etc and brakes {.`requireSpacesInAnonymousFunctionExpression,requireSpacesInCallExpression,requireSpacesInConditionalExpression,requireSpacesInForStatement,requireSpacesInFunctionDeclaration,requireSpacesInFunctionExpression,requireSpacesInFunction,requireSpacesInNamedFunctionExpression`
  - [x] Put spaces after : in property declarations/objects definitions. `"requireSpaceAfterObjectKeys": true`
  - [x] Use Spaces after and before ( and ) and [ and ]. `"requireSpacesInsideParentheses":"all","requireSpacesInsideArrayBrackets": "all"`
  - [x] Use Spaces after and before = assigning values. `"requireSpaceAfterBinaryOperators":["="],"requireSpaceBeforeBinaryOperators":["="]`
  - [x] Don't use spaces after unary operators such as ! or ++. `"disallowSpaceAfterPrefixUnaryOperators":["++", "--", "+", "-", "~", "!"]`
  - [x] Use space after , in arguments variable. `"validateParameterSeparator":", "`
  - [x] Declaring Objects using multi-line. `"requireMultipleVarDecl":true`
  - [x] Declaring variables using multi-line. `"requireMultipleVarDecl":true`
  - [x] Always use semicolons ;. `"requireSemicolons":true`
  - [x] put spaces after double slash. `("requireSpaceAfterLineComment":true)`
  - [x] Any , must not have preceding space `"disallowSpaceAfterBinaryOperators":[","],`
  - [x] Use $ in front of a variable if it's a jquery object. `requireDollarBeforejQueryAssignment:true`
  - [x] General guidelines
    - [x] `"disallowMixedSpacesAndTabs": true`
    - [x] `"disallowMultipleSpaces":true`
    - [x] `"disallowTrailingComma":true`
    - [x] `"requireLineFeedAtFileEnd":true`

Style guidelines which do not have jshint / jscsc equivalents:
- When chained methods make long lines, divide each method on mutiple lines. **[Issue raised with JSCS](https://github.com/jscs-dev/node-jscs/issues/1448)**
- Use double slash // for comments block **[Issue raised with JSCS](https://github.com/jscs-dev/node-jscs/issues/1443)**
- ; must not have preceding space. **[Issue raised with JSCS](https://github.com/jscs-dev/node-jscs/issues/1447)**
